### PR TITLE
feature: update nav bar, footer, check eligibility and sysadmin page

### DIFF
--- a/app/frontend/components/domains/home/super-admin-home-screen.tsx
+++ b/app/frontend/components/domains/home/super-admin-home-screen.tsx
@@ -11,7 +11,7 @@ export const SuperAdminHomeScreen = ({ ...rest }: IHomeScreenProps) => {
 
   return (
     <Flex as="main" direction="column" w="full" bg="greys.white" pb="24">
-      <BlueTitleBar title={t("home.superAdminTitle")} />
+      <BlueTitleBar title={t("home.systemAdminTitle")} />
       <Container maxW="container.md" py={16}>
         <Flex direction="column" align="center" w="full">
           <Flex direction="column" align="center" w="full" gap={6}>

--- a/app/frontend/components/domains/home/super-admin-home-screen.tsx
+++ b/app/frontend/components/domains/home/super-admin-home-screen.tsx
@@ -1,58 +1,69 @@
-import { Container, Flex, Heading } from "@chakra-ui/react"
-import { BookOpen, Buildings, ChartBar, FileLock, FileText, Pencil } from "@phosphor-icons/react"
+import { Container, Flex } from "@chakra-ui/react"
+import { BookOpen, Buildings, Clock, FileText, Folder, Pencil } from "@phosphor-icons/react"
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { IHomeScreenProps } from "."
+import { BlueTitleBar } from "../../shared/base/blue-title-bar"
 import { HomeScreenBox } from "./home-screen-box"
 
 export const SuperAdminHomeScreen = ({ ...rest }: IHomeScreenProps) => {
   const { t } = useTranslation()
 
   return (
-    <Container maxW="container.md" py={16}>
-      <Flex direction="column" align="center" w="full">
-        <Heading as="h1" mb={8}>
-          {t("home.superAdminTitle")}
-        </Heading>
-        <Flex direction="column" align="center" w="full" gap={6}>
-          <HomeScreenBox
-            title={t("home.jurisdictionsTitle")}
-            description={t("home.jurisdictionsDescription")}
-            icon={<Buildings size={24} />}
-            href="/jurisdictions"
-          />
-          <HomeScreenBox
-            title={t("home.permitTemplateCatalogueTitle")}
-            description={t("home.permitTemplateCatalogueDescription")}
-            icon={<FileText size={24} />}
-            href="/requirement-templates"
-          />
-          <HomeScreenBox
-            title={t("home.requirementsLibraryTitle")}
-            description={t("home.requirementsLibraryDescription")}
-            icon={<BookOpen size={24} />}
-            href="/requirements-library"
-          />
-          <HomeScreenBox
-            title={t("home.earlyAccess.title")}
-            description={t("home.earlyAccess.adminDescription")}
-            icon={<FileLock size={24} />}
-            href="/early-access"
-          />
-          <HomeScreenBox
-            title={t("home.reportingTitle")}
-            description={t("home.reportingDescription")}
-            icon={<ChartBar size={24} />}
-            href="/reporting"
-          />
-          <HomeScreenBox
-            title={t("home.configurationManagement.title")}
-            description={t("home.configurationManagement.adminDescription")}
-            icon={<Pencil size={24} />}
-            href="/configuration-management"
-          />
+    <Flex as="main" direction="column" w="full" bg="greys.white" pb="24">
+      <BlueTitleBar title={t("home.superAdminTitle")} />
+      <Container maxW="container.md" py={16}>
+        <Flex direction="column" align="center" w="full">
+          <Flex direction="column" align="center" w="full" gap={6}>
+            <HomeScreenBox
+              title={t("home.jurisdictionsTitle")}
+              description={t("home.jurisdictionsDescription")}
+              icon={<Buildings size={24} />}
+              href="/jurisdictions"
+            />
+            <HomeScreenBox
+              title={t("home.permitTemplateCatalogueTitle")}
+              description={t("home.permitTemplateCatalogueDescription")}
+              icon={<FileText size={24} />}
+              href="/requirement-templates"
+              linkText={t("ui.create")}
+            />
+            <HomeScreenBox
+              title={t("home.requirementsLibraryTitle")}
+              description={t("home.requirementsLibraryDescription")}
+              icon={<BookOpen size={24} />}
+              href="/requirements-library"
+              linkText={t("ui.create")}
+            />
+            <HomeScreenBox
+              title={t("home.configurationManagement.title")}
+              description={t("home.configurationManagement.adminDescription")}
+              icon={<Pencil size={24} />}
+              href="/configuration-management"
+            />
+            <HomeScreenBox
+              title={t("home.reportingTitle")}
+              description={t("home.reportingDescription")}
+              icon={<Folder size={24} />}
+              href="/reporting"
+              pointerEvents="none"
+              opacity={0.6}
+              bg="gray.100"
+              linkText={t("ui.comingSoon")}
+            />
+            <HomeScreenBox
+              title={t("home.earlyAccess.title")}
+              description={t("home.earlyAccess.adminDescription")}
+              icon={<Clock size={24} />}
+              href="/early-access"
+              pointerEvents="none"
+              opacity={0.6}
+              bg="gray.100"
+              linkText={t("ui.comingSoon")}
+            />
+          </Flex>
         </Flex>
-      </Flex>
-    </Container>
+      </Container>
+    </Flex>
   )
 }

--- a/app/frontend/components/domains/navigation/nav-bar.tsx
+++ b/app/frontend/components/domains/navigation/nav-bar.tsx
@@ -5,6 +5,7 @@ import {
   Flex,
   HStack,
   Heading,
+  Hide,
   IconButton,
   Image,
   Link,
@@ -17,12 +18,11 @@ import {
   MenuList,
   Portal,
   Show,
-  Hide,
   Spacer,
   Text,
   VStack,
 } from "@chakra-ui/react"
-import { Envelope, Folders, List, Warning } from "@phosphor-icons/react"
+import { Folders, List, Warning } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import * as R from "ramda"
 import React, { useState } from "react"
@@ -106,7 +106,7 @@ export const NavBar = observer(function NavBar() {
   const { sessionStore, userStore, notificationStore, uiStore, sandboxStore } = useMst()
 
   const { currentUser } = userStore
-  const { loggedIn,logout } = sessionStore
+  const { loggedIn, logout } = sessionStore
   const { criticalNotifications } = notificationStore
   const { rmJurisdictionSelectKey } = uiStore
 
@@ -123,8 +123,8 @@ export const NavBar = observer(function NavBar() {
         as="nav"
         id="mainNav"
         w="full"
-        bg={currentUser?.isSubmitter || !loggedIn ? "greys.white" : "theme.blue"}
-        color={currentUser?.isSubmitter || !loggedIn ? "theme.blue" : "greys.white"}
+        bg={"greys.white"}
+        color={"text.primary"}
         zIndex={10}
         borderBottomWidth={2}
         borderColor="border.light"
@@ -139,7 +139,7 @@ export const NavBar = observer(function NavBar() {
                   htmlHeight="30.853px"
                   htmlWidth="145.386px"
                   alt={t("site.linkHome")}
-                  src={currentUser?.isSubmitter || !loggedIn ? "/images/logo.png" : "/images/logo-light.svg"}
+                  src={"/images/logo.png"}
                 />
               </Box>
             </RouterLink>
@@ -148,10 +148,6 @@ export const NavBar = observer(function NavBar() {
                 <HStack>
                   <Text fontSize="xl" fontWeight="normal" mb="0" whiteSpace="nowrap">
                     {currentUser?.isSuperAdmin ? t("site.adminNavBarTitle") : t("site.title")}
-                  </Text>
-
-                  <Text fontSize="sm" textTransform="uppercase" color="theme.yellow" fontWeight="bold">
-                    {t("site.beta")}
                   </Text>
                 </HStack>
                 {currentUser?.isReviewStaff && (
@@ -197,7 +193,7 @@ export const NavBar = observer(function NavBar() {
                 </VStack>
               )}
               {currentUser?.isSuperAdmin && (
-                <Text color="greys.white" textTransform="capitalize">
+                <Text color="text.primary" textTransform="capitalize">
                   {t(`user.roles.${currentUser.role as EUserRoles}`)}
                 </Text>
               )}
@@ -208,30 +204,26 @@ export const NavBar = observer(function NavBar() {
                   </RouterLinkButton>
                 </Show>
               )} */}
-              {loggedIn && (
-                <NotificationsPopover
-                  aria-label="notifications popover"
-                  color={currentUser?.isSubmitter || !loggedIn ? "theme.blue" : "greys.white"}
-                />
+              {loggedIn && <NotificationsPopover aria-label="notifications popover" color="text.primary" />}
+
+              <NavBarMenu />
+              {!currentUser?.isSuperAdmin && (
+                <Show above="lg">
+                  <RouterLinkButton variant="tertiary" color="text.primary" to={"/get-support"}>
+                    {t("site.support.getSupport")}
+                  </RouterLinkButton>
+                </Show>
               )}
-              <Hide above="md">
-                <NavBarMenu />
-              </Hide>
-              <Show above="md">
-                <RouterLinkButton variant="tertiary" color="greys.grey100" to={"/get-support"}>
-                  {t("site.support.getSupport")}
-                </RouterLinkButton>
-              </Show>
               {!loggedIn && (
-                <Show above="md">
-                  <RouterLinkButton variant="tertiary" color="greys.grey100" to="/login">
+                <Show above="lg">
+                  <RouterLinkButton variant="tertiary" color="text.primary" to="/login">
                     {t("auth.login")}
                   </RouterLinkButton>
                 </Show>
               )}
-              {loggedIn && (
+              {loggedIn && !currentUser?.isSuperAdmin && (
                 <Show above="md">
-                  <RouterLinkButton variant="tertiary" color="greys.grey100" onClick={handleClickLogout}>
+                  <RouterLinkButton variant="tertiary" color="text.primary" onClick={handleClickLogout}>
                     {t("auth.logout")}
                   </RouterLinkButton>
                 </Show>
@@ -310,10 +302,10 @@ const NavBarMenu = observer(function NavBarMenu({}: INavBarMenuProps) {
 
   const superAdminOnlyItems = (
     <MenuGroup>
-      <NavMenuItem label={t("home.permitTemplateCatalogueTitle")} to={"/requirement-templates"} />
+      <NavMenuItem label={t("home.permitTemplateCatalogueTitleShort")} to={"/requirement-templates"} />
       <NavMenuItem label={t("home.requirementsLibraryTitle")} to={"/requirements-library"} />
       <NavMenuItem label={t("home.configurationManagement.title")} to={"/configuration-management"} />
-      <NavMenuItem label={t("home.earlyAccess.title")} to={"/early-access"} />
+      <NavMenuItem label={t("home.auditLog")} to={"/audit-log"} />
       <MenuDivider my={0} borderColor="border.light" />
     </MenuGroup>
   )
@@ -378,10 +370,10 @@ const NavBarMenu = observer(function NavBarMenu({}: INavBarMenuProps) {
         <MenuButton
           as={Button}
           borderRadius="lg"
-          border={currentUser?.isSubmitter || !loggedIn ? "solid black" : "solid white"}
+          border="solid black"
           borderWidth="1px"
           p={3}
-          variant={currentUser?.isSubmitter || !loggedIn ? "primaryInverse" : "primary"}
+          variant="primaryInverse"
           aria-label="menu dropdown button"
           leftIcon={<List size={16} weight="bold" />}
         >
@@ -394,42 +386,33 @@ const NavBarMenu = observer(function NavBarMenu({}: INavBarMenuProps) {
           <MenuList zIndex={99} boxShadow="2xl">
             {loggedIn && !currentUser.isUnconfirmed ? (
               <>
-                <Text fontSize="xs" fontStyle="italic" px={3} mb={-1} color="greys.grey01">
-                  {t("site.loggedInWelcome")}
-                </Text>
-                <MenuGroup title={currentUser.name} noOfLines={1}>
-                  <MenuDivider my={0} borderColor="border.light" />
-                  <NavMenuItem label={t("site.home")} to={"/"} />
-                  <MenuDivider my={0} borderColor="border.light" />
-                  {!currentUser.isReviewStaff && (
-                    <NavMenuItem label={t("home.jurisdictionsTitle")} to={"/jurisdictions"} />
-                  )}
-                  {currentUser?.isSuperAdmin && superAdminOnlyItems}
-                  {(currentUser?.isReviewManager || currentUser?.isRegionalReviewManager) && reviewManagerOnlyItems}
-                  {(currentUser?.isSuperAdmin ||
-                    currentUser?.isReviewManager ||
-                    currentUser?.isRegionalReviewManager) &&
-                    adminOrManagerItems}
-                  {currentUser?.isReviewer && reviwerOnlyItems}
-                  {currentUser?.isSubmitter && submitterOnlyItems}
-                  {currentUser?.isReviewStaff && reviewStaffOnlyItems}
-                  {!currentUser?.isSubmitter && (
-                    <>
-                      <MenuItem bg="greys.grey03" onClick={(e) => navigate("/permit-applications/new")}>
-                        <Button as={Box} variant="primary">
-                          {t("site.newApplication")}
-                        </Button>
-                      </MenuItem>
-                      <NavMenuItem label={t("site.myPermits")} to="/permit-applications" bg="greys.grey03" />
-                      <MenuDivider my={0} borderColor="border.light" />
-                    </>
-                  )}
-                  <HelpDrawer
-                    renderTriggerButton={({ onClick }) => <NavMenuItem label={t("ui.help")} onClick={onClick} />}
-                  />
-                  <NavMenuItem label={t("user.myProfile")} to={"/profile"} />
-                  <NavMenuItem label={t("auth.logout")} onClick={handleClickLogout} />
-                </MenuGroup>
+                <MenuDivider my={0} borderColor="border.light" />
+                <NavMenuItem label={t("site.home")} to={"/"} />
+                {!currentUser.isReviewStaff && (
+                  <NavMenuItem label={t("home.jurisdictionsTitle")} to={"/jurisdictions"} />
+                )}
+                {currentUser?.isSuperAdmin && superAdminOnlyItems}
+                {(currentUser?.isReviewManager || currentUser?.isRegionalReviewManager) && reviewManagerOnlyItems}
+                {(currentUser?.isSuperAdmin || currentUser?.isReviewManager || currentUser?.isRegionalReviewManager) &&
+                  adminOrManagerItems}
+                {currentUser?.isReviewer && reviwerOnlyItems}
+                {currentUser?.isSubmitter && submitterOnlyItems}
+                {currentUser?.isReviewStaff && reviewStaffOnlyItems}
+
+                {currentUser?.isSubmitter && (
+                  <>
+                    <MenuItem bg="greys.grey03" onClick={(e) => navigate("/permit-applications/new")}>
+                      <Button as={Box} variant="primary">
+                        {t("site.newApplication")}
+                      </Button>
+                    </MenuItem>
+                    <NavMenuItem label={t("site.myPermits")} to="/permit-applications" bg="greys.grey03" />
+                    <MenuDivider my={0} borderColor="border.light" />
+                  </>
+                )}
+                <MenuDivider my={0} borderColor="border.light" />
+                <NavMenuItem label={t("user.myAccount")} to={"/profile"} />
+                <NavMenuItem label={t("auth.logout")} onClick={handleClickLogout} />
               </>
             ) : (
               <>
@@ -453,13 +436,6 @@ const NavBarMenu = observer(function NavBarMenu({}: INavBarMenuProps) {
                 {loggedIn && <NavMenuItem label={t("auth.logout")} onClick={handleClickLogout} />}
               </>
             )}
-
-            <MenuDivider my={0} borderColor="border.light" />
-            <MenuItem>
-              <Link textDecoration="none" w="full" href={"mailto:" + t("site.contactEmail")} isExternal>
-                {t("site.giveFeedback")} <Envelope size={16} style={{ display: "inline", color: "inherit" }} />
-              </Link>
-            </MenuItem>
           </MenuList>
         </Box>
       </Portal>

--- a/app/frontend/components/domains/navigation/nav-bar.tsx
+++ b/app/frontend/components/domains/navigation/nav-bar.tsx
@@ -194,7 +194,7 @@ export const NavBar = observer(function NavBar() {
               )}
               {currentUser?.isSuperAdmin && (
                 <Text color="text.primary" textTransform="capitalize">
-                  {t(`user.roles.${currentUser.role as EUserRoles}`)}
+                  {t("user.roles.system_admin")}
                 </Text>
               )}
               {/* {(!loggedIn || currentUser?.isSubmitter) && (

--- a/app/frontend/components/shared/base/footer.tsx
+++ b/app/frontend/components/shared/base/footer.tsx
@@ -10,6 +10,7 @@ export const Footer = observer(() => {
   const location = useLocation()
   const {
     sessionStore: { loggedIn },
+    userStore: { currentUser },
   } = useMst()
   const { t } = useTranslation()
   const onlyShowFooterOnRoutes = [
@@ -24,7 +25,9 @@ export const Footer = observer(() => {
     "/get-support",
   ]
 
-  const shouldShowFooter = onlyShowFooterOnRoutes.some((route) => location.pathname.startsWith(route))
+  const shouldShowFooter = onlyShowFooterOnRoutes.some(
+    (route) => location.pathname.startsWith(route) || (location.pathname === "/" && !currentUser?.isSubmitter)
+  )
 
   return (
     <>

--- a/app/frontend/components/shared/base/question-card.tsx
+++ b/app/frontend/components/shared/base/question-card.tsx
@@ -73,10 +73,6 @@ const QuestionCard: React.FC<QuestionCardProps> = ({ question, answers, onAnswer
                   borderColor="border.light"
                   justifyContent="center"
                   width={{ base: "100%", md: "calc(22% - 14px)" }}
-                  height={{
-                    base: "calc(70px + 1vw)",
-                    md: "calc(28px + 2vw)",
-                  }}
                 >
                   <Radio value={answer}>
                     <Text>{answer}</Text>

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -428,6 +428,7 @@ const options = {
           seeLiveButton: "See Live",
           invite: "Invite",
           public: "Public",
+          comingSoon: "Coming soon",
         },
         notification: {
           title: "Notifications",
@@ -1687,11 +1688,13 @@ const options = {
           },
         },
         home: {
-          jurisdictionsTitle: "Jurisdictions",
+          auditLog: "Audit Log",
+          jurisdictionsTitle: "Programs",
           siteConfigurationTitle: "Configuration management",
           jurisdictionsDescription:
             "Administer Review Managers and their roles within local jurisdictions through the Building Permit Hub. This includes inviting or removing managers, managing overall jurisdictions, customizing community pages, and handling jurisdiction-specific settings.",
-          permitTemplateCatalogueTitle: "Permit templates catalogue",
+          permitTemplateCatalogueTitle: "Applications templates catalogue",
+          permitTemplateCatalogueTitleShort: "Applications catalogue",
           reportingTitle: "Reporting",
           reportingDescription:
             "Explore reports and analytics to gain insights and make informed decisions about your permit applications",
@@ -1784,7 +1787,7 @@ const options = {
               description: "Manage API keys for the Building Permit Hub.",
             },
           },
-          superAdminTitle: "Admin home",
+          superAdminTitle: "System admin portal",
           submissionsInboxTitle: "Submissions inbox",
           submissionsInboxDescription: "View all submitted building permit applications.",
           permitsTitle: "Digital building permits",
@@ -1920,7 +1923,7 @@ const options = {
             regional_review_manager: "regional review manager",
             review_manager: "review manager",
             reviewer: "reviewer",
-            super_admin: "super admin",
+            super_admin: "system admin",
           },
           rolesExplanation: {
             submitter:
@@ -2343,7 +2346,7 @@ const options = {
         site: {
           title: "Better Homes Energy Savings Program application",
           titleLong: "Better Homes Energy Savings Program",
-          adminNavBarTitle: "Building Permit Hub - Admin Panel",
+          adminNavBarTitle: "Better Homes Energy Savings Program application",
           adminPanel: "Admin Panel",
           beta: "Beta",
           linkHome: "Navigate home",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1788,6 +1788,7 @@ const options = {
             },
           },
           superAdminTitle: "System admin portal",
+          systemAdminTitle: "System admin portal",
           submissionsInboxTitle: "Submissions inbox",
           submissionsInboxDescription: "View all submitted building permit applications.",
           permitsTitle: "Digital building permits",
@@ -1923,7 +1924,8 @@ const options = {
             regional_review_manager: "regional review manager",
             review_manager: "review manager",
             reviewer: "reviewer",
-            super_admin: "system admin",
+            super_admin: "super admin",
+            system_admin: "system admin",
           },
           rolesExplanation: {
             submitter:


### PR DESCRIPTION
Updated the System Admin Portal page
- Changed the names and link names
- Updated nav bar
- Added footer
- Logged in user removed from menu for sysadmins
- Changed title

Nav bar 
- is white for all displayed users. Used to be blue for everyone except submitters
- Removed beta text
- When logged out the get support and login are displayed above "Lg" threshold
- used text.primary as the text color

Removed fixed height from the Kind of Homes question card