### PR TITLE
feature Implement application assignment notifications and update the…

### DIFF
--- a/app/controllers/api/concerns/search/program_users.rb
+++ b/app/controllers/api/concerns/search/program_users.rb
@@ -46,20 +46,8 @@ module Api::Concerns::Search::ProgramUsers
     end
 
     # Filter users based on assignment permissions
-    if Current.user.admin_manager?
-      # Admin managers can assign to admin_managers and admins
-      invalid_user_ids =
-        User
-          .where(id: user_ids)
-          .where.not(role: %w[admin_manager admin])
-          .pluck(:id)
-      user_ids -= invalid_user_ids
-    elsif Current.user.admin?
-      # Admins can only assign to admins
-      invalid_user_ids =
-        User.where(id: user_ids).where.not(role: "admin").pluck(:id)
-      user_ids -= invalid_user_ids
-    end
+    user_ids =
+      ApplicationAssignmentPolicy.assignable_user_ids(Current.user, user_ids)
 
     # Run the search
     @user_search =

--- a/app/controllers/api/concerns/search/program_users.rb
+++ b/app/controllers/api/concerns/search/program_users.rb
@@ -45,6 +45,22 @@ module Api::Concerns::Search::ProgramUsers
       user_ids -= system_admin_ids
     end
 
+    # Filter users based on assignment permissions
+    if Current.user.admin_manager?
+      # Admin managers can assign to admin_managers and admins
+      invalid_user_ids =
+        User
+          .where(id: user_ids)
+          .where.not(role: %w[admin_manager admin])
+          .pluck(:id)
+      user_ids -= invalid_user_ids
+    elsif Current.user.admin?
+      # Admins can only assign to admins
+      invalid_user_ids =
+        User.where(id: user_ids).where.not(role: "admin").pluck(:id)
+      user_ids -= invalid_user_ids
+    end
+
     # Run the search
     @user_search =
       User.search(

--- a/app/frontend/stores/notification-store.ts
+++ b/app/frontend/stores/notification-store.ts
@@ -141,7 +141,8 @@ export const NotificationStoreModel = types
         case ENotificationActionType.applicationSubmission:
         case ENotificationActionType.applicationRevisionsRequest:
         case ENotificationActionType.applicationView:
-        case ENotificationActionType.applicationIneligible: {
+        case ENotificationActionType.applicationIneligible:
+        case ENotificationActionType.applicationAssignment: {
           const data = objectData as IPermitNotificationObjectData;
           return [
             {

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -505,6 +505,7 @@ export enum ENotificationActionType {
   applicationView = 'application_view',
   applicationIneligible = 'application_ineligible',
   applicationWithdrawal = 'application_withdrawal',
+  applicationAssignment = 'application_assignment',
   accountUpdate = 'account_update',
   newSubmissionReceived = 'new_submission_received',
   templatePublished = 'template_published',

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -614,6 +614,20 @@ class PermitApplication < ApplicationRecord
     }
   end
 
+  def application_assignment_event_notification_data
+    {
+      "id" => SecureRandom.uuid,
+      "action_type" =>
+        Constants::NotificationActionTypes::APPLICATION_ASSIGNMENT,
+      "action_text" =>
+        "#{I18n.t("notification.permit_application.assignment_notification", number: number, program_name: program_name)}",
+      "object_data" => {
+        "permit_application_id" => id,
+        "permit_application_number" => number
+      }
+    }
+  end
+
   def step_code_requirements
     jurisdiction.permit_type_required_steps.where(permit_type_id:)
   end

--- a/app/policies/application_assignment_policy.rb
+++ b/app/policies/application_assignment_policy.rb
@@ -1,6 +1,6 @@
 class ApplicationAssignmentPolicy < ApplicationPolicy
-  def initialize(user, record)
-    @user = user
+  def initialize(user_context, record)
+    super(user_context, record)
     @permit_application = record[:permit_application]
     @assigned_user = record[:assigned_user]
   end
@@ -25,5 +25,5 @@ class ApplicationAssignmentPolicy < ApplicationPolicy
 
   private
 
-  attr_reader :user, :permit_application, :assigned_user
+  attr_reader :permit_application, :assigned_user
 end

--- a/app/policies/application_assignment_policy.rb
+++ b/app/policies/application_assignment_policy.rb
@@ -23,6 +23,21 @@ class ApplicationAssignmentPolicy < ApplicationPolicy
     false
   end
 
+  # Class method to filter user IDs based on assignment permissions
+  def self.assignable_user_ids(current_user, user_ids)
+    return [] unless current_user.admin_manager? || current_user.admin?
+
+    if current_user.admin_manager?
+      # Admin managers can assign to admin_managers and admins
+      User.where(id: user_ids, role: %w[admin_manager admin]).pluck(:id)
+    elsif current_user.admin?
+      # Admins can only assign to admins
+      User.where(id: user_ids, role: "admin").pluck(:id)
+    else
+      []
+    end
+  end
+
   private
 
   attr_reader :permit_application, :assigned_user

--- a/app/policies/application_assignment_policy.rb
+++ b/app/policies/application_assignment_policy.rb
@@ -1,0 +1,29 @@
+class ApplicationAssignmentPolicy < ApplicationPolicy
+  def initialize(user, record)
+    @user = user
+    @permit_application = record[:permit_application]
+    @assigned_user = record[:assigned_user]
+  end
+
+  def create?
+    # Basic permission check - can this user assign applications at all?
+    return false unless user.admin_manager? || user.admin?
+
+    # assigned_user is required for assignment authorization
+    return false if assigned_user.nil?
+
+    # Admin managers can assign to admin managers and admins
+    if user.admin_manager?
+      return assigned_user.admin_manager? || assigned_user.admin?
+    end
+
+    # Admins can only assign to other admins
+    return assigned_user.admin? if user.admin?
+
+    false
+  end
+
+  private
+
+  attr_reader :user, :permit_application, :assigned_user
+end

--- a/app/policies/permit_application_policy.rb
+++ b/app/policies/permit_application_policy.rb
@@ -85,10 +85,6 @@ class PermitApplicationPolicy < ApplicationPolicy
     user.admin_manager? || user.admin?
   end
 
-  def assign_user_to_application?
-    user.admin_manager?
-  end
-
   def create_permit_collaboration?
     permit_collaboration = record
 

--- a/app/policies/program_policy.rb
+++ b/app/policies/program_policy.rb
@@ -32,7 +32,7 @@ class ProgramPolicy < ApplicationPolicy
   end
 
   def search_users?
-    update?
+    user.system_admin? || user.admin_manager? || user.admin?
   end
 
   def search_permit_applications?

--- a/app/services/constants/notification_action_types.rb
+++ b/app/services/constants/notification_action_types.rb
@@ -20,5 +20,6 @@ module Constants
     ACCOUNT_UPDATE = "account_update"
     NEW_SUBMISSION_RECEIVED = "new_submission_received"
     TEMPLATE_PUBLISHED = "template_published"
+    APPLICATION_ASSIGNMENT = "application_assignment"
   end
 end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -415,6 +415,7 @@ class NotificationService
             deactivated_at: nil
           }
         )
+        .distinct
 
     notification_user_hash = {}
 
@@ -443,6 +444,7 @@ class NotificationService
             deactivated_at: nil
           }
         )
+        .distinct
 
     notification_user_hash = {}
 
@@ -452,6 +454,21 @@ class NotificationService
       ] = template_version.template_published_notification_data
     end
 
+    unless notification_user_hash.empty?
+      NotificationPushJob.perform_async(notification_user_hash)
+    end
+  end
+
+  def self.publish_application_assignment_event(
+    permit_application,
+    assigned_user
+  )
+    notification_user_hash = {
+      assigned_user.id =>
+        permit_application.application_assignment_event_notification_data
+    }
+
+    # Send in-app notification only (no email required)
     unless notification_user_hash.empty?
       NotificationPushJob.perform_async(notification_user_hash)
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -723,6 +723,7 @@ en:
       ineligible_notification_with_reason: 'Application %{number} has been marked as ineligible for the %{program_name}. The reason is: %{reason}'
       withdrawal_notification: 'Your application %{number} has been withdrawn from the %{program_name}'
       new_submission_received_notification: 'New application %{number} submitted to %{program_name} on %{submitted_at}'
+      assignment_notification: 'Application %{number} from %{program_name} has been assigned to you'
     user:
       account_update_notification: 'Your account was updated on %{updated_at}. Changes: %{changed_fields}. If you did not make this change, please contact support immediately.'
     permit_collaboration:


### PR DESCRIPTION
… assignment authorization policies

Implemented the notification when an application is assigned to a user
Changed the search on the Submission Inbox screen so that the logged in user can only see users that they can assign to

Updated the Policy so that it behaves like this:
Admin Managers can assign to Admin Manages and Admins
Admins can assign to other Admins
Participants and System Admins can't assign to anyone. 
The reason System Admins can't assign is because they don't have access to an inbox