### PR TITLE
fix: enhance notification system UX with increased page size and cou…

### DIFF
--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -13,6 +13,7 @@ class Api::NotificationsController < Api::ApplicationController
                      blueprint: NotificationBlueprint,
                      meta: {
                        total_pages: @notification_feed[:total_pages],
+                       total_count: @notification_feed[:total_count],
                        unread_count: nf.unread_count,
                        last_read_at: nf.last_read
                      }

--- a/app/frontend/components/domains/home/notifications/notifications-popover.tsx
+++ b/app/frontend/components/domains/home/notifications/notifications-popover.tsx
@@ -45,6 +45,7 @@ export const NotificationsPopover: React.FC<INotificationsPopoverProps> = observ
     deleteNotification,
     clearAllNotifications,
     unreadNotificationsCount,
+    totalCount,
   } = notificationStore;
 
   useEffect(() => {
@@ -112,16 +113,23 @@ export const NotificationsPopover: React.FC<INotificationsPopoverProps> = observ
                 <Heading as="h3" fontSize="lg" mb={0}>
                   {t('notification.title')}
                 </Heading>
-                {/* Use numberJustRead for the popover header badge */}
-                {numberJustRead > 0 && (
-                  <Badge fontWeight="normal" textTransform="lowercase">
-                    {t('notification.nUnread', { n: numberJustRead })}
-                  </Badge>
+                {/* Show total count and unread count */}
+                {(totalCount > 0 || notifications.length > 0) && (
+                  <Flex gap={2}>
+                    <Badge fontWeight="normal" textTransform="lowercase" variant="outline">
+                      {t('notification.nTotal', { count: totalCount || notifications.length })}
+                    </Badge>
+                    {numberJustRead > 0 && (
+                      <Badge fontWeight="normal" textTransform="lowercase" colorScheme="blue">
+                        {t('notification.nUnread', { n: numberJustRead })}
+                      </Badge>
+                    )}
+                  </Flex>
                 )}
               </Flex>
             </Flex>
           </PopoverHeader>
-          <PopoverBody p={4} maxH="50vh" overflow="auto">
+          <PopoverBody p={4} maxH="70vh" overflow="auto">
             <Flex direction="column" gap={4}>
               {R.isEmpty(notificationsToShow) ? (
                 <Text color="greys.grey01">{t('notification.noUnread')}</Text>

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -522,6 +522,8 @@ const options = {
         },
         notification: {
           title: 'Notifications',
+          nTotal: '{{count}} notification',
+          nTotal_other: '{{count}} notifications',
           nUnread: '{{ n }} new',
           noUnread: 'No unread notifications',
           clearAll: 'Clear All',

--- a/app/frontend/stores/notification-store.ts
+++ b/app/frontend/stores/notification-store.ts
@@ -21,6 +21,7 @@ export const NotificationStoreModel = types
     notifications: types.array(types.frozen<INotification>()),
     page: types.maybeNull(types.number),
     totalPages: types.maybeNull(types.number),
+    totalCount: types.maybeNull(types.number),
     isLoaded: types.maybeNull(types.boolean),
     unreadNotificationsCount: types.optional(types.number, 0),
     popoverOpen: types.optional(types.boolean, false),
@@ -216,13 +217,14 @@ export const NotificationStoreModel = types
         const {
           data: {
             data,
-            meta: { unreadCount, totalPages },
+            meta: { unreadCount, totalPages, totalCount = 0 },
           },
         } = response;
 
         self.unreadNotificationsCount = unreadCount;
         opts.reset ? self.setNotifications(data) : self.concatToNotifications(data);
         self.totalPages = totalPages;
+        self.totalCount = totalCount;
         self.page = self.nextPage;
         self.isLoaded = true;
       } else {
@@ -299,6 +301,7 @@ export const NotificationStoreModel = types
         if (response.ok) {
           self.notifications.clear();
           self.unreadNotificationsCount = 0;
+          self.totalCount = 0;
         } else {
           console.error('[Error] clearAllNotifications: API call failed', response);
         }

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -5,7 +5,8 @@ class NotificationService
   end
 
   def self.total_page_count(total_count)
-    (total_count.to_f / (ENV["NOTIFICATION_FEED_PER_PAGE"] || 5) || 5).ceil
+    page_size = (ENV["NOTIFICATION_FEED_PER_PAGE"] || 50).to_i
+    (total_count.to_f / page_size).ceil
   end
 
   def self.user_feed_for(user_id, page)
@@ -25,11 +26,13 @@ class NotificationService
         end
         .compact
 
+    total_count = activity_metadata(user_id, uf, :total_count)
+
     {
       feed_items: feed_items,
       feed_object: uf,
-      total_pages:
-        total_page_count(activity_metadata(user_id, uf, :total_count)),
+      total_pages: total_page_count(total_count),
+      total_count: total_count,
       unread_count: activity_metadata(user_id, uf, :unread_count)
     }
   end

--- a/config/initializers/simple_feed.rb
+++ b/config/initializers/simple_feed.rb
@@ -44,7 +44,8 @@ SimpleFeed.define(:user_feed) do |f|
       )
   end
 
-  f.per_page = (ENV["NOTIFICATION_FEED_PER_PAGE"] || 5).to_i
-  f.batch_size = (ENV["NOTIFICATION_FEED_PER_PAGE"] || 5).to_i * 3
+  page_size = (ENV["NOTIFICATION_FEED_PER_PAGE"] || 50).to_i
+  f.per_page = page_size
+  f.batch_size = page_size * 3
   f.max_size = 100
 end


### PR DESCRIPTION
…t badges

  - Increase notification page size from 5 to 50 per load to reduce clicks
  - Add total count and unread count badges to notification popover header
  - Expand container height from 50vh to 70vh for better visibility
  - Add proper i18n support for notification count pluralization
  - Include total_count in API response for accurate frontend display
  - Fix React timing issue with async state using frontend fallback pattern
  - Simplify environment variable handling in SimpleFeed configuration

  Users can now see up to 50 notifications at once instead of clicking
  "See more" 5 times, significantly improving the notification experience.