### PR TITLE
feature: send a notification email to the participant when an admin u…

### DIFF
--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -506,6 +506,7 @@ export enum ENotificationActionType {
   applicationIneligible = 'application_ineligible',
   applicationWithdrawal = 'application_withdrawal',
   applicationAssignment = 'application_assignment',
+  adminUpdatedParticipantApp = 'admin_updated_participant_app',
   accountUpdate = 'account_update',
   newSubmissionReceived = 'new_submission_received',
   templatePublished = 'template_published',

--- a/app/helpers/permit_hub_mailer_helper.rb
+++ b/app/helpers/permit_hub_mailer_helper.rb
@@ -1,0 +1,6 @@
+module PermitHubMailerHelper
+  def participant_greeting
+    name_parts = [@participant_first_name, @participant_last_name].compact
+    name_parts.any? ? " #{name_parts.join(" ")}" : ""
+  end
+end

--- a/app/mailers/permit_hub_mailer.rb
+++ b/app/mailers/permit_hub_mailer.rb
@@ -224,4 +224,26 @@ class PermitHubMailer < ApplicationMailer
       }
     )
   end
+
+  def notify_admin_updated_participant_app(
+    permit_application,
+    participant_email
+  )
+    @permit_application = permit_application
+    @program = permit_application.program
+    @participant_email = participant_email
+
+    # Extract participant name from submission data
+    name_data = permit_application.extract_participant_name_from_submission_data
+    @participant_first_name = name_data[:first_name]
+    @participant_last_name = name_data[:last_name]
+
+    send_mail(
+      email: participant_email,
+      template_key: "notify_admin_updated_participant_app",
+      subject_i18n_params: {
+        permit_application_number: permit_application.number
+      }
+    )
+  end
 end

--- a/app/services/constants/notification_action_types.rb
+++ b/app/services/constants/notification_action_types.rb
@@ -21,5 +21,6 @@ module Constants
     NEW_SUBMISSION_RECEIVED = "new_submission_received"
     TEMPLATE_PUBLISHED = "template_published"
     APPLICATION_ASSIGNMENT = "application_assignment"
+    ADMIN_UPDATED_PARTICIPANT_APP = "admin_updated_participant_app"
   end
 end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -477,6 +477,19 @@ class NotificationService
     end
   end
 
+  def self.publish_admin_updated_participant_app_event(permit_application)
+    # Only send email to the participant's email address (no in-app notification)
+    # since there's no link between the application and a user in the user table
+    participant_email = permit_application.extract_email_from_submission_data
+
+    if participant_email.present?
+      PermitHubMailer.notify_admin_updated_participant_app(
+        permit_application,
+        participant_email
+      ).deliver_now
+    end
+  end
+
   # this is just a wrapper around the activity's metadata methods
   # since in the case of a single instance it returns a specific return type (eg. Integer)
   # but in the case of multiple user_ids the activity is a hash object

--- a/app/views/permit_hub_mailer/notify_admin_updated_participant_app.erb
+++ b/app/views/permit_hub_mailer/notify_admin_updated_participant_app.erb
@@ -1,0 +1,7 @@
+<p>Hello<%= participant_greeting %>,</p>
+
+<p>Your Better Homes Energy Savings Program application <%= @permit_application.number %> has been updated by our team.</p>
+
+<p>If you have any questions, please call us at 1-833-856-0333 or email us at <a href="mailto:BetterHomesESP@clearesult.com">BetterHomesESP@clearesult.com</a>.</p>
+
+<p>Thank you,<br>Energy Savings Program Support</p>

--- a/app/views/permit_hub_mailer/notify_submitter_application_submitted.html.erb
+++ b/app/views/permit_hub_mailer/notify_submitter_application_submitted.html.erb
@@ -1,9 +1,11 @@
-<h1><%= @permit_application.resubmitted? ? "Your permit application has been resubmitted." : "Your Better Homes Energy Savings Program application has been received." %></h1>
-
 <p>Hello <%= @user.first_name %> <%= @user.last_name %>,</p>
 
+<% if @permit_application.resubmitted? %>
+<p>Your permit application has been resubmitted.</p>
+<% end %>
+
 <p>
-  <%= @permit_application.resubmitted? ? "Thank you for revising your permit application. Your revised application has been received and is pending review." : "We’ve received your application to the Better Homes Energy Savings Program." %>
+  <%= @permit_application.resubmitted? ? "Thank you for revising your permit application. Your revised application has been received and is pending review." : "We've received your application to the Better Homes Energy Savings Program." %>
 <br>Your application number: <%= @permit_application.number %></p>
 <!-- Button Start -->
 <div style="margin: 24px 0; text-align: left;">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,6 +160,7 @@ en:
       notify_batched_integration_mapping: 'New API mappings'
       notify_application_withdrawn: 'Application %{permit_application_number} has been withdrawn'
       notify_application_ineligible: 'Application %{permit_application_number} is ineligible'
+      notify_admin_updated_participant_app: 'Your application has been updated'
   arbitrary_message_construct:
     devise:
       failure:


### PR DESCRIPTION
…pdates their app

  Implement email-only notification system that sends emails to participants
  when administrators update their applications and change status from
  "update_needed" or "revisions_requested" to "newly_submitted" or "resubmitted".

  Key features:
  - Model callback triggers on status changes for internal applications
  - Dynamic email extraction from JSONB submission data
  - Personalized emails with participant names from form data
  - Uses Rails mailer helper for clean template logic
  - Production-ready with debug logging removed

  Files modified:
  - Add notification constant and frontend enum
  - Implement model callback and email extraction methods
  - Add notification service and mailer methods
  - Create email template with participant greeting helper
  - Add i18n email subject translation