### PR TITLE
 feature: add 24-hour incomplete draft notification system for partic…

### DIFF
--- a/app/frontend/stores/notification-store.ts
+++ b/app/frontend/stores/notification-store.ts
@@ -143,11 +143,12 @@ export const NotificationStoreModel = types
         case ENotificationActionType.applicationRevisionsRequest:
         case ENotificationActionType.applicationView:
         case ENotificationActionType.applicationIneligible:
-        case ENotificationActionType.applicationAssignment: {
+        case ENotificationActionType.applicationAssignment:
+        case ENotificationActionType.participantIncompleteDraftNotification: {
           const data = objectData as IPermitNotificationObjectData;
           return [
             {
-              text: t('ui.show'),
+              text: t('ui.view'),
               href: getApplicationLink(data.permitApplicationId, true),
             },
           ];

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -507,6 +507,7 @@ export enum ENotificationActionType {
   applicationWithdrawal = 'application_withdrawal',
   applicationAssignment = 'application_assignment',
   adminUpdatedParticipantApp = 'admin_updated_participant_app',
+  participantIncompleteDraftNotification = 'participant_incomplete_draft_notification',
   accountUpdate = 'account_update',
   newSubmissionReceived = 'new_submission_received',
   templatePublished = 'template_published',

--- a/app/jobs/participant_incomplete_draft_notification_job.rb
+++ b/app/jobs/participant_incomplete_draft_notification_job.rb
@@ -1,0 +1,24 @@
+class ParticipantIncompleteDraftNotificationJob
+  include Sidekiq::Worker
+  sidekiq_options queue: :default
+
+  def perform(permit_application_id)
+    permit_application = PermitApplication.find_by(id: permit_application_id)
+
+    # Application no longer exists, skip notification
+    return unless permit_application
+
+    # Check if application is still in draft status
+    # Only send notification if it's still in draft after 24 hours
+    return unless permit_application.status == "new_draft"
+
+    # Check if submitter still exists and is active
+    return unless permit_application.submitter
+    return if permit_application.submitter.discarded?
+
+    # Send the notification
+    NotificationService.publish_participant_incomplete_draft_notification_event(
+      permit_application
+    )
+  end
+end

--- a/app/mailers/permit_hub_mailer.rb
+++ b/app/mailers/permit_hub_mailer.rb
@@ -246,4 +246,18 @@ class PermitHubMailer < ApplicationMailer
       }
     )
   end
+
+  def notify_participant_incomplete_draft_notification(permit_application)
+    @user = permit_application.submitter
+    @permit_application = permit_application
+    @program = permit_application.program
+
+    send_user_mail(
+      email: @user.email,
+      template_key: "notify_participant_incomplete_draft_notification",
+      subject_i18n_params: {
+        permit_application_number: permit_application.number
+      }
+    )
+  end
 end

--- a/app/services/constants/notification_action_types.rb
+++ b/app/services/constants/notification_action_types.rb
@@ -22,5 +22,7 @@ module Constants
     TEMPLATE_PUBLISHED = "template_published"
     APPLICATION_ASSIGNMENT = "application_assignment"
     ADMIN_UPDATED_PARTICIPANT_APP = "admin_updated_participant_app"
+    PARTICIPANT_INCOMPLETE_DRAFT_NOTIFICATION =
+      "participant_incomplete_draft_notification"
   end
 end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -490,6 +490,23 @@ class NotificationService
     end
   end
 
+  def self.publish_participant_incomplete_draft_notification_event(
+    permit_application
+  )
+    notification_user_hash = {
+      permit_application.submitter_id =>
+        permit_application.participant_incomplete_draft_notification_event_notification_data
+    }
+
+    PermitHubMailer.notify_participant_incomplete_draft_notification(
+      permit_application
+    )&.deliver_later
+
+    unless notification_user_hash.empty?
+      NotificationPushJob.perform_async(notification_user_hash)
+    end
+  end
+
   # this is just a wrapper around the activity's metadata methods
   # since in the case of a single instance it returns a specific return type (eg. Integer)
   # but in the case of multiple user_ids the activity is a hash object

--- a/app/views/permit_hub_mailer/notify_participant_incomplete_draft_notification.erb
+++ b/app/views/permit_hub_mailer/notify_participant_incomplete_draft_notification.erb
@@ -1,0 +1,24 @@
+<p>Hello <%= @user.first_name %> <%= @user.last_name %>,</p>
+
+<p>This is a reminder that your application to the Better Homes Energy Savings Program is still in draft. You can go to your application by clicking the button below:</p>
+
+<!-- Button Start -->
+<div style="margin: 24px 0; text-align: left;">
+  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace:0pt; mso-table-rspace:0pt; border-collapse: separate !important;">
+    <tr>
+      <td align="center" bgcolor="#013366" role="presentation"
+          style="background:#013366; border:1px solid #013366; border-radius:4px; cursor:auto; mso-padding-alt:6px 12px;" valign="middle">
+        <a href="<%= FrontendUrlHelper.frontend_url("/applications/#{@permit_application.id}/edit") %>"
+           style="display:inline-block; color:#ffffff !important; font-family:'BC Sans', 'Segoe UI', Arial, sans-serif; font-size:16px; font-weight:400; line-height:27px; margin:0; text-decoration:none !important; padding:6px 12px; mso-padding-alt:0px; border-radius:4px; mso-line-height-rule:exactly;"
+           target="_blank">
+          View Application
+        </a>
+      </td>
+    </tr>
+  </table>
+</div>
+<!-- Button End -->
+
+<p>If you have any questions, please call us at 1-833-856-0333 or email us at <a href="mailto:BetterHomesESP@clearesult.com">BetterHomesESP@clearesult.com</a>.</p>
+
+<p>Thank you,<br>Energy Savings Program Support</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,7 @@ en:
       notify_application_withdrawn: 'Application %{permit_application_number} has been withdrawn'
       notify_application_ineligible: 'Application %{permit_application_number} is ineligible'
       notify_admin_updated_participant_app: 'Your application has been updated'
+      notify_participant_incomplete_draft_notification: 'Reminder: Your recently created application'
   arbitrary_message_construct:
     devise:
       failure:
@@ -725,6 +726,7 @@ en:
       withdrawal_notification: 'Your application %{number} has been withdrawn from the %{program_name}'
       new_submission_received_notification: 'New application %{number} submitted to %{program_name} on %{submitted_at}'
       assignment_notification: 'Application %{number} from %{program_name} has been assigned to you'
+      participant_incomplete_draft_notification: 'This is a reminder that your application to the %{program_name} is still in draft. You can complete your application by viewing it here'
     user:
       account_update_notification: 'Your account was updated on %{updated_at}. Changes: %{changed_fields}. If you did not make this change, please contact support immediately.'
     permit_collaboration:


### PR DESCRIPTION
…ipants, admins and admin managers

  Implement automated notification system that reminds participants about
  incomplete draft applications after 24 hours of inactivity.

  Features:
  - Automatic job scheduling when draft applications are created
  - Both email and in-app notifications sent after 24-hour delay
  - Background job with comprehensive safety checks
  - Email template with direct link to continue application
  - Proper i18n support for all user-facing text

  Technical implementation:
  - Added ParticipantIncompleteDraftNotificationJob with Sidekiq
  - Model callbacks for automatic scheduling/cancellation
  - NotificationService integration following existing patterns
  - Frontend enum and notification store updates
  - Email template matching existing design patterns

  Safety features:
  - Job only executes if application still in draft status
  - Validates submitter exists and is active
  - Uses send_user_mail for proper user confirmation checks
  - Graceful handling of deleted applications/users

  Also fixes: jurisdiction_qualified_name bug in assign_default_nickname
  method that prevented PermitApplication creation.