### PR TITLE
fix: improve nil handling in PermitApplication methods for number_pre…

### DIFF
--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -350,7 +350,7 @@ class PermitApplication < ApplicationRecord
   end
 
   def number_prefix
-    jurisdiction&.prefix
+    jurisdiction&.prefix || ""
   end
 
   def notifiable_users
@@ -400,7 +400,7 @@ class PermitApplication < ApplicationRecord
 
   def days_ago_submitted
     # Calculate the difference in days between the current date and the submitted_at date
-    return 0 unless submitted_at
+    return nil unless submitted_at
     (Date.current - submitted_at.to_date).to_i
   end
 
@@ -421,7 +421,8 @@ class PermitApplication < ApplicationRecord
   end
 
   def permit_type_and_activity
-    "#{activity&.name} - #{permit_type&.name}".strip
+    return "" unless activity && permit_type
+    "#{activity.name} - #{permit_type.name}".strip
   end
 
   def confirmed_permit_type_submission_contacts


### PR DESCRIPTION
…fix, days_ago_submitted, and permit_type_and_activity

  - number_prefix: return empty string instead of nil for safer string ops
  - days_ago_submitted: return nil instead of 0 for never-submitted apps  
  - permit_type_and_activity: handle missing associations gracefully

  Follow-up improvements after notification feature implementation."