### PR TITLE
  fix: refine update field editability and allow uploads in updates

### DIFF
--- a/app/frontend/components/domains/energy-savings-application/revision-sidebar.tsx
+++ b/app/frontend/components/domains/energy-savings-application/revision-sidebar.tsx
@@ -17,6 +17,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 import { CaretRight, ChatDots, PaperPlaneTilt } from '@phosphor-icons/react';
+import { format } from 'date-fns';
 import { observer } from 'mobx-react-lite';
 import React, { MutableRefObject, useEffect, useMemo, useState } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
@@ -405,7 +406,7 @@ interface IRevisionRequestListItemProps {
 const RevisionRequestListItem = ({ revisionRequest }: IRevisionRequestListItemProps) => {
   const { t } = useTranslation();
 
-  const { requirementJson, reasonCode, comment, user } = revisionRequest;
+  const { requirementJson, reasonCode, comment, user, createdAt, submissionJson } = revisionRequest;
 
   const clickHandleView = () => {
     document.dispatchEvent(new CustomEvent('openRequestRevision', { detail: { key: requirementJson.key } }));
@@ -415,7 +416,7 @@ const RevisionRequestListItem = ({ revisionRequest }: IRevisionRequestListItemPr
     <ListItem mb={4} w="full">
       <ScrollLink to={`formio-component-${requirementJson.key}`}>{requirementJson.label}</ScrollLink>
       <Flex fontStyle="italic">
-        {t('energySavingsApplication.show.revision.reasonCode')}: {reasonCode}
+        {t('energySavingsApplication.show.revision.reason')}: {reasonCode}
       </Flex>
       <Flex gap={2} fontStyle="italic" alignItems="center" flexWrap="nowrap" w="full">
         <Box width={6} height={6}>
@@ -427,9 +428,33 @@ const RevisionRequestListItem = ({ revisionRequest }: IRevisionRequestListItemPr
           {t('ui.view')}
         </Button>
       </Flex>
+      {/* Original answer display */}
+      <Box mt={1} fontStyle="italic">
+        <Text>
+          {t('energySavingsApplication.show.revision.originalAnswer')}:&nbsp;
+          {(() => {
+            const fieldKey = requirementJson?.key;
+            const reqSubmission = submissionJson as any;
+            if (typeof reqSubmission === 'string') return reqSubmission;
+            if (reqSubmission?.data && fieldKey) {
+              const fieldValue = reqSubmission.data[fieldKey];
+              if (fieldValue !== undefined && fieldValue !== null && fieldValue !== '') {
+                return String(fieldValue);
+              }
+            }
+            return t('energySavingsApplication.show.revision.noOriginalAnswer');
+          })()}
+        </Text>
+      </Box>
       {user && (
         <Text fontStyle={'italic'}>
-          {t('ui.modifiedBy')}: {user.firstName} {user.lastName}
+          {t('ui.editedBy')}: {user.firstName} {user.lastName}
+        </Text>
+      )}
+      {createdAt && (
+        <Text fontStyle={'italic'}>
+          {/* Using YYYY-MM-DD */}
+          {t('ui.dateEdited')}: {format(new Date(createdAt), 'yyyy-MM-dd')}
         </Text>
       )}
     </ListItem>

--- a/app/frontend/components/shared/energy-savings-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/energy-savings-applications/requirement-form.tsx
@@ -317,28 +317,39 @@ export const RequirementForm = observer(
 
       const clonedFormJson = JSON.parse(JSON.stringify(formattedFormJson));
 
+      // Calculate shared variables once outside loops for performance
+      const isRealParticipant = currentUser?.role === 'participant';
+      const isDraftApplication = permitApplication?.status === 'draft' || permitApplication?.status === 'new_draft';
+      const isRevisionsRequested = permitApplication?.status === 'revisions_requested';
+      const revisionRequests = permitApplication?.latestRevisionRequests || [];
+
       // Set individual field disabled states based on isEditing (pathway-aware)
       clonedFormJson.components?.forEach((section: any) => {
         section.components?.forEach((block: any) => {
           block.components?.forEach((requirement: any) => {
+            // Check if field has revision request (per-field calculation)
+            const hasRevisionRequestInLatest = revisionRequests.some(
+              (rr) => rr.requirementJson?.key === requirement.key,
+            );
+
             // Handle submit-related components first
             if (
               requirement.key === 'submit' ||
               requirement.key?.includes('acknowledge') ||
               requirement.key?.includes('signature')
             ) {
-              // Simple logic using React state instead of complex MobX/backend checks
-              const isRealParticipant = currentUser?.role === 'participant';
-              const isDraftApp = permitApplication?.status === 'draft' || permitApplication?.status === 'new_draft';
               const isStaffPathway = performedBy === 'staff';
 
               // Enable submit for:
-              // 1. Real participant users
-              // 2. Draft applications (new creation)
-              // 3. Staff pathway AFTER Save Edits button clicked (simple React state)
-              const staffCanSubmit = isDraftApp || (isStaffPathway && saveEditsCompleted);
+              // 1. Draft applications (creation phase)
+              // 2. Participants during revisions (ANY field has revision requests)
+              // 3. Staff pathway AFTER Save Edits clicked
+              const hasAnyRevisionRequests = revisionRequests.length > 0;
+              const participantCanSubmit =
+                isRealParticipant && (isDraftApplication || (isRevisionsRequested && hasAnyRevisionRequests));
+              const staffCanSubmit = isDraftApplication || (isStaffPathway && saveEditsCompleted);
 
-              requirement.disabled = !(staffCanSubmit || isRealParticipant);
+              requirement.disabled = !(participantCanSubmit || staffCanSubmit);
               return;
             }
 
@@ -356,22 +367,18 @@ export const RequirementForm = observer(
             // Set field disabled state - fields only editable after pencil workflow
             // Everyone (including admin staff pathway) must click pencil → "Update Field" first
 
-            // Check if field has been unlocked via pencil workflow (has revision request)
-            const revisionRequests = permitApplication?.latestRevisionRequests || [];
-            const hasRevisionRequestInLatest = revisionRequests.some(
-              (rr) => rr.requirementJson?.key === requirement.key,
-            );
+            // Field editability processing (hasRevisionRequestInLatest calculated above)
 
-            // Field is editable if:
-            // 1. Real participant user (always can edit), OR
-            // 2. Draft application (new app creation), OR
-            // 3. Has revision request (pencil workflow completed) AND isEditing (correct pathway)
-            const isRealParticipant = currentUser?.role === 'participant';
-            const isDraftApplication =
-              permitApplication?.status === 'draft' || permitApplication?.status === 'new_draft';
-            const adminCanEdit = hasRevisionRequestInLatest && isEditing;
+            // Field editability logic:
+            // 1. Draft applications: All users can edit all fields (creation phase)
+            // 2. Participants: Only flagged fields during revisions
+            // 3. Admins: Only on "staff" pathway (not "send to submitter")
+            const participantCanEdit =
+              isRealParticipant && (isDraftApplication || (isRevisionsRequested && hasRevisionRequestInLatest));
+            const adminCanEdit =
+              isDraftApplication || (hasRevisionRequestInLatest && isEditing && performedBy === 'staff');
 
-            requirement.disabled = !(isRealParticipant || isDraftApplication || adminCanEdit);
+            requirement.disabled = !(participantCanEdit || adminCanEdit);
           });
         });
       });

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -494,6 +494,8 @@ const options = {
           toTop: 'Go to top',
           confirm: 'Confirm',
           modifiedBy: 'Modified by',
+          editedBy: 'Edited by',
+          dateEdited: 'Date edited',
           searchAddresses: 'Search addresses',
           typeToSearch: 'Begin typing to search',
           close: 'Close',

--- a/app/policies/permit_application_policy.rb
+++ b/app/policies/permit_application_policy.rb
@@ -55,7 +55,36 @@ class PermitApplicationPolicy < ApplicationPolicy
   end
 
   def upload_supporting_document?
-    record.draft? && record.submitter == user
+    case record.status
+    when "new_draft"
+      # Only submitter can upload during creation
+      record.submitter == user
+    when "newly_submitted", "resubmitted"
+      # Admin editing phase: submitter OR admin (same program) can upload
+      is_admin_in_program =
+        (user.admin_manager? || user.admin?) &&
+          user.program_memberships.active.exists?(program_id: record.program_id)
+      record.submitter == user || is_admin_in_program
+    when "revisions_requested"
+      # Upload permissions based on chosen pathway
+      latest_revision_requests =
+        record.latest_submission_version&.revision_requests
+      performed_by = latest_revision_requests&.first&.performed_by
+
+      if performed_by == "staff"
+        # Admin "on behalf": editing complete, no uploads
+        false
+      elsif performed_by == "applicant"
+        # "Send to submitter": only participant can upload
+        record.submitter == user
+      else
+        # Fallback: only submitter
+        record.submitter == user
+      end
+    else
+      # No uploads for other states
+      false
+    end
   end
 
   def destroy?


### PR DESCRIPTION
  - Add comprehensive upload permission matrix with program isolation
  - Fix participant field editability to only allow flagged fields during revisions
  - Optimize form performance by calculating shared variables once outside loops
  - Add pathway-aware admin permissions (staff vs applicant delegation)
  - Improve revision sidebar with original answers and better timestamps
  - Fix submit button logic to check for ANY revision requests