### PR TITLE
fix(BCHEP-658): Add updated_at to the external API /applications/{id}…

### DIFF
--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -237,7 +237,12 @@ class PermitApplicationBlueprint < Blueprinter::Base
 
   view :external_api do
     identifier :id
-    fields :status, :number, :full_address, :submitted_at, :resubmitted_at
+    fields :status,
+           :number,
+           :full_address,
+           :submitted_at,
+           :resubmitted_at,
+           :updated_at
 
     field :submission_data do |pa, _options|
       pa.formatted_submission_data_for_external_use

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -169,8 +169,7 @@ in this document.
                 type: :number,
                 format: :int64,
                 description:
-                  "Datetime in milliseconds since the epoch (Unix time). This is the timestamp of the last update to the application record.",
-                nullable: true
+                  "Datetime in milliseconds since the epoch (Unix time). This is the timestamp of the last update to the application record."
               },
               user_group_type: {
                 type: :string,

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -165,6 +165,13 @@ in this document.
                   "Datetime in milliseconds since the epoch (Unix time). This is the timestamp when the application was last resubmitted due to a revision request. Note: there might be multiple resubmissions for an application, but this date is the last resubmission date.",
                 nullable: true
               },
+              updated_at: {
+                type: :number,
+                format: :int64,
+                description:
+                  "Datetime in milliseconds since the epoch (Unix time). This is the timestamp of the last update to the application record.",
+                nullable: true
+              },
               user_group_type: {
                 type: :string,
                 enum: %w[participant contractor],

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -1392,6 +1392,12 @@ components:
             request. Note: there might be multiple resubmissions for an application,
             but this date is the last resubmission date.'
           nullable: true
+        updated_at:
+          type: number
+          format: int64
+          description: Datetime in milliseconds since the epoch (Unix time). This
+            is the timestamp of the last update to the application record.
+          nullable: true
         user_group_type:
           type: string
           enum:

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -1397,7 +1397,6 @@ components:
           format: int64
           description: Datetime in milliseconds since the epoch (Unix time). This
             is the timestamp of the last update to the application record.
-          nullable: true
         user_group_type:
           type: string
           enum:


### PR DESCRIPTION
…. When the webhook fires the updated_at should match the time the admin marked the application as In Review