### PR TITLE
feat(BCHEP-658): Add the screened_in_at date to the database and also…

### DIFF
--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -242,7 +242,8 @@ class PermitApplicationBlueprint < Blueprinter::Base
            :full_address,
            :submitted_at,
            :resubmitted_at,
-           :updated_at
+           :updated_at,
+           :screened_in_at
 
     field :submission_data do |pa, _options|
       pa.formatted_submission_data_for_external_use

--- a/app/models/concerns/permit_application_status.rb
+++ b/app/models/concerns/permit_application_status.rb
@@ -25,8 +25,8 @@ module PermitApplicationStatus
 
   included do
     after_initialize :set_flow
+    before_save :set_screened_in_at
     after_update :check_ineligible_transition
-    after_update :check_screen_in_transition
     after_save :reset_flow_if_status_changed
 
     # Let model calls (like application.submit?) proxy to the flow
@@ -69,9 +69,9 @@ module PermitApplicationStatus
     klass.new(self)
   end
 
-  def check_screen_in_transition
-    if saved_change_to_status? && status == "in_review" && screened_in_at.nil?
-      update_column(:screened_in_at, Time.current)
+  def set_screened_in_at
+    if status_changed? && status == "in_review" && screened_in_at.nil?
+      self.screened_in_at = Time.current
     end
   end
 

--- a/app/models/concerns/permit_application_status.rb
+++ b/app/models/concerns/permit_application_status.rb
@@ -26,6 +26,7 @@ module PermitApplicationStatus
   included do
     after_initialize :set_flow
     after_update :check_ineligible_transition
+    after_update :check_screen_in_transition
     after_save :reset_flow_if_status_changed
 
     # Let model calls (like application.submit?) proxy to the flow
@@ -66,6 +67,12 @@ module PermitApplicationStatus
     key = [submission_type&.code, user_group_type&.code, audience_type&.code]
     klass = FLOW_MAP[key] || ApplicationFlow::Default
     klass.new(self)
+  end
+
+  def check_screen_in_transition
+    if saved_change_to_status? && status == "in_review" && screened_in_at.nil?
+      update_column(:screened_in_at, Time.current)
+    end
   end
 
   def check_ineligible_transition

--- a/db/migrate/20260504204952_add_screened_in_at_to_permit_applications.rb
+++ b/db/migrate/20260504204952_add_screened_in_at_to_permit_applications.rb
@@ -1,0 +1,5 @@
+class AddScreenedInAtToPermitApplications < ActiveRecord::Migration[7.1]
+  def change
+    add_column :permit_applications, :screened_in_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -420,6 +420,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_19_222612) do
     t.string "reference_number"
     t.jsonb "compliance_data", default: {}, null: false
     t.datetime "revisions_requested_at", precision: nil
+    t.datetime "screened_in_at"
     t.boolean "first_nations", default: false
     t.uuid "sandbox_id"
     t.uuid "program_id"

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -171,6 +171,13 @@ in this document.
                 description:
                   "Datetime in milliseconds since the epoch (Unix time). This is the timestamp of the last update to the application record."
               },
+              screened_in_at: {
+                type: :number,
+                format: :int64,
+                description:
+                  "Datetime in milliseconds since the epoch (Unix time). This is the timestamp when the application was screened in (moved to in review) by program staff.",
+                nullable: true
+              },
               user_group_type: {
                 type: :string,
                 enum: %w[participant contractor],

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -1402,6 +1402,13 @@ components:
           format: int64
           description: Datetime in milliseconds since the epoch (Unix time). This
             is the timestamp of the last update to the application record.
+        screened_in_at:
+          type: number
+          format: int64
+          description: Datetime in milliseconds since the epoch (Unix time). This
+            is the timestamp when the application was screened in (moved to in review)
+            by program staff.
+          nullable: true
         user_group_type:
           type: string
           enum:


### PR DESCRIPTION
… to the results from the endpoints: /applications/{id} and /invoices/{id}