### PR TITLE
fix(BCHEP-672): Reduce AwsCredentialRefreshJob log noise

### DIFF
--- a/app/jobs/aws_credential_health_check_job.rb
+++ b/app/jobs/aws_credential_health_check_job.rb
@@ -82,13 +82,13 @@ class AwsCredentialHealthCheckJob
           Rails.logger.error "❌ Emergency credential refresh failed"
 
           # Queue the job as fallback
-          AwsCredentialRefreshJob.perform_later
+          AwsCredentialRefreshJob.perform_async
         end
       rescue => e
         Rails.logger.error "Emergency refresh failed with exception: #{e.message}"
 
         # Queue the job as fallback
-        AwsCredentialRefreshJob.perform_later
+        AwsCredentialRefreshJob.perform_async
       end
     end
 

--- a/app/jobs/aws_credential_refresh_job.rb
+++ b/app/jobs/aws_credential_refresh_job.rb
@@ -1,11 +1,9 @@
-class AwsCredentialRefreshJob < ApplicationJob
-  queue_as :default
-
-  # Retry configuration for critical credential refresh
-  retry_on StandardError, wait: :exponentially_longer, attempts: 3
+class AwsCredentialRefreshJob
+  include Sidekiq::Job
+  sidekiq_options queue: :default, retry: 3, log_level: :warn
 
   def perform
-    Rails.logger.info "Starting scheduled AWS credential refresh job"
+    Rails.logger.debug "Starting scheduled AWS credential refresh job"
 
     service = AwsCredentialRefreshService.new
 
@@ -14,7 +12,7 @@ class AwsCredentialRefreshJob < ApplicationJob
 
     begin
       if service.refresh_credentials!
-        Rails.logger.info "✅ Scheduled AWS credential refresh completed successfully"
+        Rails.logger.debug "✅ Scheduled AWS credential refresh completed successfully"
 
         # Refresh S3 storage clients to use new credentials
         refresh_shrine_clients
@@ -62,7 +60,7 @@ class AwsCredentialRefreshJob < ApplicationJob
       attempts += 1
 
       if service.test_credentials
-        Rails.logger.info "✅ New credentials tested and working (attempt #{attempts})"
+        Rails.logger.debug "✅ New credentials tested and working (attempt #{attempts})"
         return true
       end
 

--- a/app/services/aws_credential_refresh_service.rb
+++ b/app/services/aws_credential_refresh_service.rb
@@ -2,11 +2,11 @@ class AwsCredentialRefreshService
   include ActiveModel::Model
 
   def refresh_credentials!
-    Rails.logger.info "Starting AWS credential refresh process"
+    Rails.logger.debug "Starting AWS credential refresh process"
 
     # Check if current credentials are still valid and not expiring soon
     if credentials_still_valid?
-      Rails.logger.info "Current credentials are still valid, skipping refresh"
+      Rails.logger.debug "Current credentials are still valid, skipping refresh"
       return true
     end
 
@@ -244,7 +244,7 @@ class AwsCredentialRefreshService
 
     # Test if credentials actually work
     if test_credentials(current_creds)
-      Rails.logger.info "Credentials valid until #{current_creds[:expires_at]} (#{time_until_expiry(current_creds[:expires_at])} remaining)"
+      Rails.logger.debug "Credentials valid until #{current_creds[:expires_at]} (#{time_until_expiry(current_creds[:expires_at])} remaining)"
       true
     else
       Rails.logger.warn "Credentials failed validation test, need refresh"

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -15,7 +15,6 @@ aws_credential_refresh:
   cron: "0 */2 * * * America/Vancouver" # Runs every 2 hours (more frequent refresh)
   class: "AwsCredentialRefreshJob"
   queue: default
-  active_job: true
 
 aws_credential_health_check:
   cron: "*/5 * * * * America/Vancouver" # Runs every 5 minutes for aggressive monitoring


### PR DESCRIPTION
  - Convert to native Sidekiq::Job with log_level: :warn
  - Move happy-path logs to debug in job, service, and shrine initializer
  - Remove active_job: true from cron config