### PR TITLE
fix(BCHEP-672): Reduce log noise. Virus scan, cleanup job, PDF dedup

### DIFF
--- a/app/jobs/cleanup_stuck_scans_job.rb
+++ b/app/jobs/cleanup_stuck_scans_job.rb
@@ -1,9 +1,8 @@
-class CleanupStuckScansJob < ApplicationJob
-  queue_as :default
+class CleanupStuckScansJob
+  include Sidekiq::Job
+  sidekiq_options queue: :default, retry: false, log_level: :warn
 
   def perform
-    Rails.logger.info "Starting cleanup of stuck virus scans"
-
     cleanup_count = 0
     error_count = 0
 

--- a/app/jobs/generate_pdf_job.rb
+++ b/app/jobs/generate_pdf_job.rb
@@ -8,7 +8,7 @@ class GeneratePdfJob
                   queue: :file_processing,
                   on_conflict: {
                     client: :log,
-                    server: :reject
+                    server: :log
                   }
 
   def self.lock_args(args)

--- a/app/services/aws_credential_refresh_service.rb
+++ b/app/services/aws_credential_refresh_service.rb
@@ -112,8 +112,6 @@ class AwsCredentialRefreshService
           return nil
         end
 
-        Rails.logger.debug "Successfully fetched current credentials from Parameter Store"
-
         return(
           {
             access_key_id: current_creds["AccessKeyID"],
@@ -270,7 +268,6 @@ class AwsCredentialRefreshService
 
       # Test by listing bucket (minimal operation)
       s3_client.head_bucket(bucket: ENV["BCGOV_OBJECT_STORAGE_BUCKET"])
-      Rails.logger.debug "AWS credentials test successful"
       true
     rescue => e
       Rails.logger.error "AWS credentials test failed: #{e.message}"

--- a/app/services/clam_av_service.rb
+++ b/app/services/clam_av_service.rb
@@ -107,7 +107,7 @@ class ClamAvService
     end
 
     result = result.strip
-    Rails.logger.info "ClamAV scan result: #{result}"
+    Rails.logger.debug "ClamAV scan result: #{result}"
 
     case result
     when /stream: OK/

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -30,8 +30,6 @@ class FileUploader < Shrine
     next unless file # Skip if no file attached
     next unless ClamAvService.enabled? # Skip if virus scanning disabled
 
-    Rails.logger.info "Performing immediate virus scan for: #{file.original_filename}"
-
     # Check if ClamAV service is reachable before proceeding
     unless ClamAvService.ping
       Rails.logger.error "ClamAV service is not reachable, skipping virus scan for development"
@@ -109,7 +107,7 @@ class FileUploader < Shrine
                             )
         end
       else
-        Rails.logger.info "File passed immediate virus scan: #{file.original_filename} (#{scan_result[:message]})"
+        # clean result logged in promote_block with filename + record ID
       end
     rescue Timeout::Error => e
       Rails.logger.error "Virus scan timeout during upload: #{e.message}"
@@ -160,8 +158,6 @@ class FileUploader < Shrine
          Thread.current[:virus_scan_result]
       scan_result = Thread.current[:virus_scan_result]
 
-      Rails.logger.info "Storing immediate virus scan results for #{attacher.record.class.name}##{attacher.record.id}"
-
       begin
         # Use update_columns to avoid callbacks and potential infinite loops
         attacher.record.update_columns(
@@ -180,7 +176,7 @@ class FileUploader < Shrine
           updated_at: Time.current
         )
 
-        Rails.logger.info "Successfully stored virus scan results: #{scan_result[:status]} for #{attacher.record.class.name}##{attacher.record.id}"
+        Rails.logger.info "Virus scan clean: #{scan_result[:original_filename]} (#{attacher.record.class.name}##{attacher.record.id})"
       rescue => e
         Rails.logger.error "Failed to store virus scan results: #{e.message}"
         Rails.logger.error e.backtrace.join("\n")

--- a/app/uploaders/file_uploader.rb
+++ b/app/uploaders/file_uploader.rb
@@ -176,7 +176,7 @@ class FileUploader < Shrine
           updated_at: Time.current
         )
 
-        Rails.logger.info "Virus scan clean: #{scan_result[:original_filename]} (#{attacher.record.class.name}##{attacher.record.id})"
+        Rails.logger.info "Virus scan #{scan_result[:status]}: #{scan_result[:original_filename]} (#{attacher.record.class.name}##{attacher.record.id})"
       rescue => e
         Rails.logger.error "Failed to store virus scan results: #{e.message}"
         Rails.logger.error e.backtrace.join("\n")

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -127,7 +127,7 @@ if SHRINE_USE_S3
     # Reset client to force credential refresh (called by cron job)
     def refresh_client!
       @client = nil
-      Rails.logger.info "S3 client refreshed - will use latest database credentials"
+      Rails.logger.debug "S3 client refreshed - will use latest database credentials"
     end
 
     # Override methods to handle credential failures gracefully

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -9,7 +9,6 @@ cleanup_stuck_scans:
   cron: "0 */6 * * * America/Vancouver" # Runs every 6 hours
   class: "CleanupStuckScansJob"
   queue: default
-  active_job: true
 
 aws_credential_refresh:
   cron: "0 */2 * * * America/Vancouver" # Runs every 2 hours (more frequent refresh)


### PR DESCRIPTION
- Virus scan: 5 lines → 1 (filename + record ID, silent on happy path)
- CleanupStuckScansJob: converted to native Sidekiq::Job, drops ActiveJob triple, 1 heartbeat line every 6h
- GeneratePdfJob: server conflict :reject → :log stops dead queue accumulation
- Removed 2 redundant AWS credential debug log lines