### PR TITLE
 fix(BCHEP-674): fix datetime precision and prevent duplicate submiss…

### DIFF
--- a/app/controllers/api/permit_applications_controller.rb
+++ b/app/controllers/api/permit_applications_controller.rb
@@ -322,7 +322,10 @@ class Api::PermitApplicationsController < Api::ApplicationController
 
     update_success = @permit_application.update(params_to_use)
     @permit_application.send(:set_flow) if update_success
-    submit_success = @permit_application.submit! if update_success
+    submit_success =
+      if update_success
+        @permit_application.with_lock { @permit_application.submit! }
+      end
 
     if update_success && submit_success
       handle_submission_notifications(@permit_application)

--- a/config/initializers/blueprinter.rb
+++ b/config/initializers/blueprinter.rb
@@ -1,6 +1,7 @@
 # epoch in milliseconds needed for js FE
 Blueprinter.configure do |config|
   config.datetime_format = ->(datetime) do
-    (datetime.respond_to?(:to_i) ? datetime.to_i : datetime.to_time.to_i) * 1000
+    dt = datetime.respond_to?(:to_f) ? datetime : datetime.to_time
+    (dt.to_f * 1000).to_i
   end
 end


### PR DESCRIPTION
…ion versions

Fix Blueprinter datetime serialization to use to_f for millisecond precision, preventing frontend sort from treating sub-second submission versions as identical

Wrap submit! in with_lock to prevent duplicate submission versions from concurrent requests