### PR TITLE
fix(BCHEP-682): pre-index status sort priority and add program_review…

### DIFF
--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -119,6 +119,16 @@ class PermitApplicationBlueprint < Blueprinter::Base
     end
   end
 
+  view :program_review_inbox do
+    include_view :base
+    exclude :sandbox
+    exclude :support_requests
+
+    field :submitter do |pa, options|
+      SubmitterBlueprint.render(pa.submitter, view: :minimal)
+    end
+  end
+
   view :extended do
     include_view :base
     fields :formatted_compliance_data, :front_end_form_update

--- a/app/controllers/api/concerns/search/permit_applications.rb
+++ b/app/controllers/api/concerns/search/permit_applications.rb
@@ -1,16 +1,6 @@
 module Api::Concerns::Search::PermitApplications
   extend ActiveSupport::Concern
 
-  # Simple status priority for business sorting
-  STATUS_PRIORITY = {
-    "newly_submitted" => 1,
-    "revisions_requested" => 2,
-    "resubmitted" => 3,
-    "in_review" => 4,
-    "ineligible" => 5,
-    "approved" => 6
-  }.freeze
-
   def perform_permit_application_search
     params = search_params
 
@@ -29,7 +19,7 @@ module Api::Concerns::Search::PermitApplications
         order: permit_application_order,
         page: params[:page],
         per_page: params[:per_page] || Kaminari.config.default_per_page,
-        includes: PermitApplication::SEARCH_INCLUDES
+        includes: permit_application_search_includes
       )
   end
 
@@ -111,24 +101,12 @@ module Api::Concerns::Search::PermitApplications
     elsif current_user.participant?
       { created_at: { order: :desc, unmapped_type: "long" } }
     else
-      # Default sort - Business priority order (simple script)
-      {
-        _script: {
-          type: "number",
-          script: {
-            source:
-              "
-              if (doc.containsKey('status') && doc['status'].size() > 0) {
-                def statusPriority = [#{status_priority_map}];
-                return statusPriority.getOrDefault(doc['status'].value, 999);
-              }
-              return 999;
-            "
-          },
-          order: "asc"
-        }
-      }
+      { status_priority: { order: :asc, unmapped_type: "long" } }
     end
+  end
+
+  def permit_application_search_includes
+    PermitApplication::SEARCH_INCLUDES
   end
 
   def permit_application_where_clause
@@ -203,10 +181,5 @@ module Api::Concerns::Search::PermitApplications
       .compact
       .except(:is_supported_applications_page)
       .merge!(where)
-  end
-
-  def status_priority_map
-    @status_priority_map ||=
-      STATUS_PRIORITY.map { |k, v| "'#{k}': #{v}" }.join(", ")
   end
 end

--- a/app/controllers/api/programs_controller.rb
+++ b/app/controllers/api/programs_controller.rb
@@ -185,7 +185,7 @@ class Api::ProgramsController < Api::ApplicationController
                      },
                      blueprint: PermitApplicationBlueprint,
                      blueprint_opts: {
-                       view: :jurisdiction_review_inbox
+                       view: :program_review_inbox
                      }
                    }
   end
@@ -205,6 +205,10 @@ class Api::ProgramsController < Api::ApplicationController
   end
 
   private
+
+  def permit_application_search_includes
+    PermitApplication::PROGRAM_SEARCH_INCLUDES
+  end
 
   def program_params
     params.require(:program).permit(

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -50,6 +50,19 @@ class PermitApplication < ApplicationRecord
     }
   ]
 
+  PROGRAM_SEARCH_INCLUDES = [
+    :submission_versions,
+    :submitter,
+    :program,
+    :assigned_users,
+    :submission_type,
+    :submission_variant,
+    :template_version,
+    :user_group_type,
+    :audience_type,
+    { template_version: { requirement_template: :audience_type } }
+  ]
+
   API_SEARCH_INCLUDES = %i[
     program
     submitter
@@ -76,6 +89,15 @@ class PermitApplication < ApplicationRecord
       ]
     }
   ]
+
+  STATUS_PRIORITY = {
+    "newly_submitted" => 1,
+    "revisions_requested" => 2,
+    "resubmitted" => 3,
+    "in_review" => 4,
+    "ineligible" => 5,
+    "approved" => 6
+  }.freeze
 
   searchkick word_middle: %i[
                number
@@ -348,6 +370,7 @@ class PermitApplication < ApplicationRecord
       screened_in_at: screened_in_at,
       viewed_at: viewed_at,
       status: status,
+      status_priority: STATUS_PRIORITY.fetch(status, 999),
       status_display: status_display_label,
       #jurisdiction_id: jurisdiction&.id,
       user_group_type_id: user_group_type&.id,


### PR DESCRIPTION
…_inbox blueprint

Replace Elasticsearch script sort with pre-indexed status_priority field. Add program_review_inbox blueprint with trimmed includes for programs inbox.