### PR TITLE
fix(BCHEP-682): add user_group_type and audience_type back to PROGRAM…

### DIFF
--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -55,7 +55,9 @@ class PermitApplication < ApplicationRecord
     { submission_versions: :supporting_documents },
     :submitter,
     :assigned_users,
-    :submission_type
+    :submission_type,
+    :user_group_type,
+    :audience_type
   ]
 
   API_SEARCH_INCLUDES = %i[


### PR DESCRIPTION
…_SEARCH_INCLUDES.

Fixes:
WARN [2026-06-03 21:16:31 +0000] : [dc915fb7-6817-40ca-8cbf-0c6cd61bd711] user: root POST /api/programs/c1c3d7f0-c47e-44d7-b716-53be9097aa51/permit_applications/search USE eager loading detected
  PermitApplication => [:audience_type]
  Add to your query: .includes([:audience_type])
Call stack
  /app/app/models/concerns/permit_application_status.rb:67:in 'PermitApplicationStatus#set_flow'
  /app/app/controllers/api/programs_controller.rb:176:in 'Api::ProgramsController#search_permit_applications'