### PR TITLE
fix(BCHEP-708): use text_middle for searching application numbers ins…

### DIFF
--- a/app/controllers/api/concerns/search/permit_applications.rb
+++ b/app/controllers/api/concerns/search/permit_applications.rb
@@ -7,11 +7,11 @@ module Api::Concerns::Search::PermitApplications
     @permit_application_search =
       PermitApplication.search(
         params[:query].presence || "*",
-        fields: %i[
-          number
-          permit_classifications
-          submitter_name
-          review_delegatee_name
+        fields: [
+          { number: :text_middle },
+          :permit_classifications,
+          :submitter_name,
+          :review_delegatee_name
         ],
         match: :word_middle,
         misspellings: false,

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -135,11 +135,11 @@ class PermitApplication < ApplicationRecord
   }.freeze
 
   searchkick word_middle: %i[
-               number
                permit_classifications
                submitter_name
                review_delegatee_name
-             ]
+             ],
+             text_middle: %i[number]
 
   # belongs_to :submitter, class_name: "User"
   belongs_to :submitter, polymorphic: true


### PR DESCRIPTION
…tead of word_middle. word_middle was interpreting the "-" as a token separator. 000-000 will match correctly now. This will also fix search for invoices and contractor onbaording forms