### PR TITLE
feat(BCHEP-694): add filters to application search/summary APIs

### DIFF
--- a/app/controllers/external_api/application_controller.rb
+++ b/app/controllers/external_api/application_controller.rb
@@ -52,6 +52,57 @@ class ExternalApi::ApplicationController < ActionController::API
     nil
   end
 
+  # Validate a single Unix-epoch-milliseconds value (the documented /search date
+  # format). Returns the integer ms on success, nil for blank, or renders a 400 +
+  # returns nil for a non-integer value (otherwise a bad value reaches
+  # Elasticsearch and raises an unhandled 500).
+  def validate_unix_ms_param(value, param_name)
+    return nil if value.blank?
+    unless value.to_s.match?(/\A-?\d+\z/)
+      render json: {
+               error:
+                 "Invalid timestamp for #{param_name}. Use Unix epoch milliseconds (integer)."
+             },
+             status: :bad_request
+      return nil
+    end
+    value.to_i
+  end
+
+  # Validate every operator value in a date-range constraint ({gte:, lte:, ...}).
+  # Returns a hash of validated ms values, or renders a 400 + returns nil.
+  def validate_unix_ms_range(range, field)
+    range.each_with_object({}) do |(op, value), out|
+      ms = validate_unix_ms_param(value, "#{field}.#{op}")
+      return nil if performed?
+      out[op] = ms unless ms.nil?
+    end
+  end
+
+  # Translate classification codes -> ids for `klass` (an STI PermitClassification
+  # subclass: UserGroupType / SubmissionType / AudienceType / SubmissionVariant).
+  # Returns [] for blank input, an array of ids on success, or renders a 400 +
+  # returns nil if any code is unknown OR doesn't belong to that dimension.
+  # (`code` is one shared enum on PermitClassification, so an unknown value would
+  # raise ArgumentError on a where(code:) — we filter to known enum keys first, and
+  # a count mismatch catches both unknown and wrong-dimension codes.)
+  def classification_ids_for(klass, codes, param_name)
+    codes = Array.wrap(codes).compact_blank.map(&:to_s)
+    return [] if codes.empty?
+
+    known = codes & PermitClassification.codes.keys
+    records = known.size == codes.size ? klass.where(code: known) : klass.none
+    if records.size != codes.size
+      bad = codes - records.map(&:code)
+      render json: {
+               error: "Invalid #{param_name}: #{bad.join(", ")}"
+             },
+             status: :bad_request
+      return nil
+    end
+    records.map(&:id)
+  end
+
   def apply_search_authorization(results, policy_action = action_name)
     results.select do |result|
       policy([:external_api, result]).send("#{policy_action}?".to_sym)

--- a/app/controllers/external_api/application_controller.rb
+++ b/app/controllers/external_api/application_controller.rb
@@ -87,7 +87,7 @@ class ExternalApi::ApplicationController < ActionController::API
   # raise ArgumentError on a where(code:) — we filter to known enum keys first, and
   # a count mismatch catches both unknown and wrong-dimension codes.)
   def classification_ids_for(klass, codes, param_name)
-    codes = Array.wrap(codes).compact_blank.map(&:to_s)
+    codes = Array.wrap(codes).compact_blank.map(&:to_s).uniq
     return [] if codes.empty?
 
     known = codes & PermitClassification.codes.keys

--- a/app/controllers/external_api/concerns/search/permit_applications.rb
+++ b/app/controllers/external_api/concerns/search/permit_applications.rb
@@ -4,10 +4,13 @@ module ExternalApi::Concerns::Search::PermitApplications
   def perform_permit_application_search
     ensure_external_api_key_authorized!
 
+    where = permit_application_where_clause
+    return if performed? # invalid classification/status code -> 400 already rendered
+
     search_conditions = {
       order: permit_application_order,
       match: :word_start,
-      where: permit_application_where_clause,
+      where: where,
       page: normalized_page(permit_application_search_params[:page]),
       per_page:
         normalized_per_page(permit_application_search_params[:per_page]),
@@ -27,9 +30,15 @@ module ExternalApi::Concerns::Search::PermitApplications
       constraints: [
         :permit_classifications,
         :status,
+        user_group_type: [],
+        submission_type: [],
+        audience_type: [],
+        submission_variant: [],
+        status: [],
         submitted_at: %i[gt lt gte lte],
         resubmitted_at: %i[gt lt gte lte],
-        screened_in_at: %i[gt lt gte lte]
+        screened_in_at: %i[gt lt gte lte],
+        updated_at: %i[gt lt gte lte]
       ],
       sort: %i[field direction]
     )
@@ -49,19 +58,65 @@ module ExternalApi::Concerns::Search::PermitApplications
   end
 
   def permit_application_where_clause
-    constraints = permit_application_search_params[:constraints]
+    constraints =
+      (
+        permit_application_search_params[:constraints] || {}
+      ).to_h.deep_symbolize_keys
 
-    where = {
-      program_id: current_external_api_key.program_id
-      # sandbox_id: current_sandbox&.id
-    }
+    where = { program_id: current_external_api_key.program_id }
 
-    # Default: filter to in_review status (for search endpoint)
-    if constraints.blank? || constraints[:status].blank?
-      where[:status] = %i[in_review]
+    # Translate classification codes -> ids (each may render a 400 + return nil).
+    {
+      user_group_type: [UserGroupType, :user_group_type_id],
+      submission_type: [SubmissionType, :submission_type_id],
+      audience_type: [AudienceType, :audience_type_id],
+      submission_variant: [SubmissionVariant, :submission_variant_id]
+    }.each do |param, (klass, field)|
+      ids = classification_ids_for(klass, constraints[param], param)
+      return if performed?
+      where[field] = ids if ids.present?
     end
 
-    where.merge!(constraints.to_h.deep_symbolize_keys) if constraints.present?
+    # Pass through the remaining constraints (permit_classifications, status, date
+    # ranges); status normalized to an array. No hardcoded in_review default —
+    # omitting status returns all statuses.
+    passthrough =
+      constraints.except(
+        :user_group_type,
+        :submission_type,
+        :audience_type,
+        :submission_variant
+      )
+
+    # Validate status against the known codes (mirrors /summary's 400; an unknown
+    # status would otherwise silently match nothing).
+    if passthrough[:status].present?
+      statuses = Array.wrap(passthrough[:status]).map(&:to_s)
+      invalid = statuses - PermitApplication.statuses.keys
+      if invalid.any?
+        render json: {
+                 error: "Invalid status: #{invalid.join(", ")}"
+               },
+               status: :bad_request
+        return
+      end
+      passthrough[:status] = statuses
+    end
+
+    # Validate date-range values are Unix-ms integers before they reach
+    # Elasticsearch (a malformed value otherwise raises an unhandled 500).
+    %i[submitted_at resubmitted_at screened_in_at updated_at].each do |field|
+      next if passthrough[field].blank?
+      validated = validate_unix_ms_range(passthrough[field], field)
+      return if performed?
+      if validated.present?
+        passthrough[field] = validated
+      else
+        passthrough.delete(field)
+      end
+    end
+
+    where.merge!(passthrough)
 
     where
   end

--- a/app/controllers/external_api/v1/permit_applications_controller.rb
+++ b/app/controllers/external_api/v1/permit_applications_controller.rb
@@ -93,6 +93,8 @@ class ExternalApi::V1::PermitApplicationsController < ExternalApi::ApplicationCo
         :submitted_to,
         :screened_in_from,
         :screened_in_to,
+        :updated_from,
+        :updated_to,
         :status,
         :page,
         :per_page
@@ -104,16 +106,22 @@ class ExternalApi::V1::PermitApplicationsController < ExternalApi::ApplicationCo
       validate_date_param(permitted[:screened_in_from], :screened_in_from)
     screened_in_to =
       validate_date_param(permitted[:screened_in_to], :screened_in_to)
+    updated_from = validate_date_param(permitted[:updated_from], :updated_from)
+    updated_to = validate_date_param(permitted[:updated_to], :updated_to)
     return if performed?
 
-    if permitted[:status].present? &&
-         !PermitApplication.statuses.key?(permitted[:status])
+    # Accept a single status code or a comma-separated list
+    # (?status=in_review or ?status=in_review,resubmitted), matching the
+    # codebase's comma-separated multi-value query convention (see visibility).
+    statuses = permitted[:status].to_s.split(",").map(&:strip).reject(&:blank?)
+    invalid_statuses = statuses - PermitApplication.statuses.keys
+    if invalid_statuses.any?
       render_error(
         nil,
         {
           status: 400,
           meta: {
-            message: "Invalid status: #{permitted[:status]}"
+            message: "Invalid status: #{invalid_statuses.join(", ")}"
           }
         }
       )
@@ -131,8 +139,8 @@ class ExternalApi::V1::PermitApplicationsController < ExternalApi::ApplicationCo
         .order(submitted_at: :desc)
 
     scope =
-      if permitted[:status].present?
-        scope.where(status: permitted[:status])
+      if statuses.any?
+        scope.where(status: statuses)
       else
         scope.where.not(status: :new_draft)
       end
@@ -157,6 +165,16 @@ class ExternalApi::V1::PermitApplicationsController < ExternalApi::ApplicationCo
         "screened_in_at <= ?",
         screened_in_to.in_time_zone.end_of_day
       ) if screened_in_to.present?
+    scope =
+      scope.where(
+        "updated_at >= ?",
+        updated_from.in_time_zone.beginning_of_day
+      ) if updated_from.present?
+    scope =
+      scope.where(
+        "updated_at <= ?",
+        updated_to.in_time_zone.end_of_day
+      ) if updated_to.present?
 
     page = normalized_page(permitted[:page])
     per_page = normalized_per_page(permitted[:per_page])

--- a/spec/requests/external_api/v1/permit_applications_spec.rb
+++ b/spec/requests/external_api/v1/permit_applications_spec.rb
@@ -52,14 +52,85 @@ RSpec.describe "external_api/v1/applications",
                         "Optional filters to narrow the search results.",
                       properties: {
                         status: {
-                          type: :string,
+                          type: :array,
+                          items: {
+                            type: :string,
+                            enum: PermitApplication.statuses.keys
+                          },
                           description:
-                            "Filter by application status. Defaults to in_review when omitted."
+                            "Filter by application status. Omit to return applications of ALL statuses. Accepts a single status code or an array of codes (e.g. \"in_review\" or [\"in_review\", \"resubmitted\"]).",
+                          example: PermitApplication.statuses.keys
                         },
                         permit_classifications: {
                           type: :string,
                           description:
-                            "Filter by permit classification keywords."
+                            "Filter by permit classification keywords (composite free-text match across the classification dimensions). Unchanged for backward compatibility."
+                        },
+                        user_group_type: {
+                          type: :array,
+                          items: {
+                            type: :string,
+                            enum: %w[participant contractor]
+                          },
+                          description:
+                            "Filter by user group; excludes other groups. Provide as an array of codes. Codes: participant, contractor. e.g. {\"user_group_type\":[\"participant\"]} returns all participant applications (internal + external) and excludes contractors.",
+                          example: %w[participant contractor]
+                        },
+                        submission_type: {
+                          type: :array,
+                          items: {
+                            type: :string,
+                            enum: %w[
+                              application
+                              onboarding
+                              support_request
+                              invoice
+                            ]
+                          },
+                          description:
+                            "Filter by application type. Provide as an array of codes. Codes: application, onboarding, support_request, invoice.",
+                          example: %w[
+                            application
+                            onboarding
+                            support_request
+                            invoice
+                          ]
+                        },
+                        audience_type: {
+                          type: :array,
+                          items: {
+                            type: :string,
+                            enum: %w[internal external]
+                          },
+                          description:
+                            "Filter by visibility context. Provide as an array of codes. Codes: internal, external.",
+                          example: %w[internal external]
+                        },
+                        submission_variant: {
+                          type: :array,
+                          items: {
+                            type: :string,
+                            enum: %w[
+                              invoice_heat_pump_space
+                              invoice_heat_pump_water
+                              invoice_insulation
+                              invoice_windows_doors
+                              invoice_ventilation
+                              invoice_electrical_upgrade
+                              invoice_health_safety
+                            ]
+                          },
+                          description:
+                            "Filter by invoice subtype (only applicable to invoices). Provide as an array of codes. Codes: invoice_heat_pump_space, invoice_heat_pump_water, invoice_insulation, invoice_windows_doors, invoice_ventilation, invoice_electrical_upgrade, invoice_health_safety.",
+                          example: %w[
+                            invoice_heat_pump_space
+                            invoice_heat_pump_water
+                            invoice_insulation
+                            invoice_windows_doors
+                            invoice_ventilation
+                            invoice_electrical_upgrade
+                            invoice_health_safety
+                          ]
                         },
                         submitted_at: {
                           "$ref" => "#/components/schemas/DateRangeFilter"
@@ -68,6 +139,9 @@ RSpec.describe "external_api/v1/applications",
                           "$ref" => "#/components/schemas/DateRangeFilter"
                         },
                         screened_in_at: {
+                          "$ref" => "#/components/schemas/DateRangeFilter"
+                        },
+                        updated_at: {
                           "$ref" => "#/components/schemas/DateRangeFilter"
                         }
                       }
@@ -326,7 +400,7 @@ RSpec.describe "external_api/v1/applications",
                   format: :date
                 },
                 description:
-                  "Filter applications submitted on or after this date (YYYY-MM-DD)",
+                  "Filter applications submitted on or after this date. YYYY-MM-DD, interpreted as a program-local Pacific (PST/PDT) calendar day; inclusive from the start of that day.",
                 required: false
 
       parameter name: :submitted_to,
@@ -336,7 +410,7 @@ RSpec.describe "external_api/v1/applications",
                   format: :date
                 },
                 description:
-                  "Filter applications submitted on or before this date (YYYY-MM-DD)",
+                  "Filter applications submitted on or before this date. YYYY-MM-DD, interpreted as a program-local Pacific (PST/PDT) calendar day; inclusive through the end of that day.",
                 required: false
 
       parameter name: :screened_in_from,
@@ -346,7 +420,7 @@ RSpec.describe "external_api/v1/applications",
                   format: :date
                 },
                 description:
-                  "Filter applications screened in on or after this date (YYYY-MM-DD)",
+                  "Filter applications screened in on or after this date. YYYY-MM-DD, interpreted as a program-local Pacific (PST/PDT) calendar day; inclusive from the start of that day.",
                 required: false
 
       parameter name: :screened_in_to,
@@ -356,16 +430,43 @@ RSpec.describe "external_api/v1/applications",
                   format: :date
                 },
                 description:
-                  "Filter applications screened in on or before this date (YYYY-MM-DD)",
+                  "Filter applications screened in on or before this date. YYYY-MM-DD, interpreted as a program-local Pacific (PST/PDT) calendar day; inclusive through the end of that day.",
+                required: false
+
+      parameter name: :updated_from,
+                in: :query,
+                schema: {
+                  type: :string,
+                  format: :date
+                },
+                description:
+                  "Filter applications last updated on or after this date. YYYY-MM-DD, interpreted as a program-local Pacific (PST/PDT) calendar day; inclusive from the start of that day.",
+                required: false
+
+      parameter name: :updated_to,
+                in: :query,
+                schema: {
+                  type: :string,
+                  format: :date
+                },
+                description:
+                  "Filter applications last updated on or before this date. YYYY-MM-DD, interpreted as a program-local Pacific (PST/PDT) calendar day; inclusive through the end of that day.",
                 required: false
 
       parameter name: :status,
                 in: :query,
                 schema: {
-                  type: :string
+                  type: :array,
+                  items: {
+                    type: :string,
+                    enum: PermitApplication.statuses.keys
+                  }
                 },
+                style: :form,
+                explode: false,
                 description:
-                  "Filter applications by status. Omit to return all applications except new_draft.",
+                  "Filter applications by status. Omit to return all applications except new_draft. Accepts a single code (?status=in_review) or a comma-separated list (?status=in_review,resubmitted).",
+                example: PermitApplication.statuses.keys,
                 required: false
 
       parameter name: :page,

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -622,23 +622,23 @@ in this document.
               "A date range filter using absolute Unix timestamps in milliseconds (a UTC-based instant, NOT a calendar date and NOT timezone-adjusted). Pass an integer epoch-ms value. To filter on a program-local (Pacific) calendar day, send the epoch-ms of local midnight for that day — e.g. the start of 2026-02-17 Pacific, not the bare date. (This differs from the /applications/summary date filters, which take Pacific-local YYYY-MM-DD calendar dates.)",
             properties: {
               gt: {
-                type: :number,
+                type: :integer,
                 format: :int64,
                 description: "Greater than (exclusive lower bound), Unix ms."
               },
               gte: {
-                type: :number,
+                type: :integer,
                 format: :int64,
                 description:
                   "Greater than or equal (inclusive lower bound), Unix ms."
               },
               lt: {
-                type: :number,
+                type: :integer,
                 format: :int64,
                 description: "Less than (exclusive upper bound), Unix ms."
               },
               lte: {
-                type: :number,
+                type: :integer,
                 format: :int64,
                 description:
                   "Less than or equal (inclusive upper bound), Unix ms."

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -619,7 +619,7 @@ in this document.
           DateRangeFilter: {
             type: :object,
             description:
-              "A date range filter using Unix timestamps in milliseconds.",
+              "A date range filter using absolute Unix timestamps in milliseconds (a UTC-based instant, NOT a calendar date and NOT timezone-adjusted). Pass an integer epoch-ms value. To filter on a program-local (Pacific) calendar day, send the epoch-ms of local midnight for that day — e.g. the start of 2026-02-17 Pacific, not the bare date. (This differs from the /applications/summary date filters, which take Pacific-local YYYY-MM-DD calendar dates.)",
             properties: {
               gt: {
                 type: :number,

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -874,17 +874,115 @@ paths:
                   description: Optional filters to narrow the search results.
                   properties:
                     status:
-                      type: string
-                      description: Filter by application status. Defaults to in_review
-                        when omitted.
+                      type: array
+                      items:
+                        type: string
+                        enum:
+                        - new_draft
+                        - newly_submitted
+                        - revisions_requested
+                        - resubmitted
+                        - in_review
+                        - update_needed
+                        - approved
+                        - ineligible
+                        - training_pending
+                        - approved_pending
+                        - approved_paid
+                      description: Filter by application status. Omit to return applications
+                        of ALL statuses. Accepts a single status code or an array
+                        of codes (e.g. "in_review" or ["in_review", "resubmitted"]).
+                      example:
+                      - new_draft
+                      - newly_submitted
+                      - revisions_requested
+                      - resubmitted
+                      - in_review
+                      - update_needed
+                      - approved
+                      - ineligible
+                      - training_pending
+                      - approved_pending
+                      - approved_paid
                     permit_classifications:
                       type: string
-                      description: Filter by permit classification keywords.
+                      description: Filter by permit classification keywords (composite
+                        free-text match across the classification dimensions). Unchanged
+                        for backward compatibility.
+                    user_group_type:
+                      type: array
+                      items:
+                        type: string
+                        enum:
+                        - participant
+                        - contractor
+                      description: 'Filter by user group; excludes other groups. Provide
+                        as an array of codes. Codes: participant, contractor. e.g.
+                        {"user_group_type":["participant"]} returns all participant
+                        applications (internal + external) and excludes contractors.'
+                      example:
+                      - participant
+                      - contractor
+                    submission_type:
+                      type: array
+                      items:
+                        type: string
+                        enum:
+                        - application
+                        - onboarding
+                        - support_request
+                        - invoice
+                      description: 'Filter by application type. Provide as an array
+                        of codes. Codes: application, onboarding, support_request,
+                        invoice.'
+                      example:
+                      - application
+                      - onboarding
+                      - support_request
+                      - invoice
+                    audience_type:
+                      type: array
+                      items:
+                        type: string
+                        enum:
+                        - internal
+                        - external
+                      description: 'Filter by visibility context. Provide as an array
+                        of codes. Codes: internal, external.'
+                      example:
+                      - internal
+                      - external
+                    submission_variant:
+                      type: array
+                      items:
+                        type: string
+                        enum:
+                        - invoice_heat_pump_space
+                        - invoice_heat_pump_water
+                        - invoice_insulation
+                        - invoice_windows_doors
+                        - invoice_ventilation
+                        - invoice_electrical_upgrade
+                        - invoice_health_safety
+                      description: 'Filter by invoice subtype (only applicable to
+                        invoices). Provide as an array of codes. Codes: invoice_heat_pump_space,
+                        invoice_heat_pump_water, invoice_insulation, invoice_windows_doors,
+                        invoice_ventilation, invoice_electrical_upgrade, invoice_health_safety.'
+                      example:
+                      - invoice_heat_pump_space
+                      - invoice_heat_pump_water
+                      - invoice_insulation
+                      - invoice_windows_doors
+                      - invoice_ventilation
+                      - invoice_electrical_upgrade
+                      - invoice_health_safety
                     submitted_at:
                       "$ref": "#/components/schemas/DateRangeFilter"
                     resubmitted_at:
                       "$ref": "#/components/schemas/DateRangeFilter"
                     screened_in_at:
+                      "$ref": "#/components/schemas/DateRangeFilter"
+                    updated_at:
                       "$ref": "#/components/schemas/DateRangeFilter"
                 sort:
                   type: object
@@ -987,35 +1085,90 @@ paths:
         schema:
           type: string
           format: date
-        description: Filter applications submitted on or after this date (YYYY-MM-DD)
+        description: Filter applications submitted on or after this date. YYYY-MM-DD,
+          interpreted as a program-local Pacific (PST/PDT) calendar day; inclusive
+          from the start of that day.
         required: false
       - name: submitted_to
         in: query
         schema:
           type: string
           format: date
-        description: Filter applications submitted on or before this date (YYYY-MM-DD)
+        description: Filter applications submitted on or before this date. YYYY-MM-DD,
+          interpreted as a program-local Pacific (PST/PDT) calendar day; inclusive
+          through the end of that day.
         required: false
       - name: screened_in_from
         in: query
         schema:
           type: string
           format: date
-        description: Filter applications screened in on or after this date (YYYY-MM-DD)
+        description: Filter applications screened in on or after this date. YYYY-MM-DD,
+          interpreted as a program-local Pacific (PST/PDT) calendar day; inclusive
+          from the start of that day.
         required: false
       - name: screened_in_to
         in: query
         schema:
           type: string
           format: date
-        description: Filter applications screened in on or before this date (YYYY-MM-DD)
+        description: Filter applications screened in on or before this date. YYYY-MM-DD,
+          interpreted as a program-local Pacific (PST/PDT) calendar day; inclusive
+          through the end of that day.
+        required: false
+      - name: updated_from
+        in: query
+        schema:
+          type: string
+          format: date
+        description: Filter applications last updated on or after this date. YYYY-MM-DD,
+          interpreted as a program-local Pacific (PST/PDT) calendar day; inclusive
+          from the start of that day.
+        required: false
+      - name: updated_to
+        in: query
+        schema:
+          type: string
+          format: date
+        description: Filter applications last updated on or before this date. YYYY-MM-DD,
+          interpreted as a program-local Pacific (PST/PDT) calendar day; inclusive
+          through the end of that day.
         required: false
       - name: status
         in: query
         schema:
-          type: string
+          type: array
+          items:
+            type: string
+            enum:
+            - new_draft
+            - newly_submitted
+            - revisions_requested
+            - resubmitted
+            - in_review
+            - update_needed
+            - approved
+            - ineligible
+            - training_pending
+            - approved_pending
+            - approved_paid
+        style: form
+        explode: false
         description: Filter applications by status. Omit to return all applications
-          except new_draft.
+          except new_draft. Accepts a single code (?status=in_review) or a comma-separated
+          list (?status=in_review,resubmitted).
+        example:
+        - new_draft
+        - newly_submitted
+        - revisions_requested
+        - resubmitted
+        - in_review
+        - update_needed
+        - approved
+        - ineligible
+        - training_pending
+        - approved_pending
+        - approved_paid
         required: false
       - name: page
         in: query
@@ -1861,7 +2014,12 @@ components:
               description: Business categories.
     DateRangeFilter:
       type: object
-      description: A date range filter using Unix timestamps in milliseconds.
+      description: A date range filter using absolute Unix timestamps in milliseconds
+        (a UTC-based instant, NOT a calendar date and NOT timezone-adjusted). Pass
+        an integer epoch-ms value. To filter on a program-local (Pacific) calendar
+        day, send the epoch-ms of local midnight for that day — e.g. the start of
+        2026-02-17 Pacific, not the bare date. (This differs from the /applications/summary
+        date filters, which take Pacific-local YYYY-MM-DD calendar dates.)
       properties:
         gt:
           type: number

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -2022,19 +2022,19 @@ components:
         date filters, which take Pacific-local YYYY-MM-DD calendar dates.)
       properties:
         gt:
-          type: number
+          type: integer
           format: int64
           description: Greater than (exclusive lower bound), Unix ms.
         gte:
-          type: number
+          type: integer
           format: int64
           description: Greater than or equal (inclusive lower bound), Unix ms.
         lt:
-          type: number
+          type: integer
           format: int64
           description: Less than (exclusive upper bound), Unix ms.
         lte:
-          type: number
+          type: integer
           format: int64
           description: Less than or equal (inclusive upper bound), Unix ms.
     ResponseError:


### PR DESCRIPTION
- /search: 4 classification filters (user_group_type, submission_type, audience_type, submission_variant) by code; multi-status; drop the hardcoded in_review default (omit status = all). Validate status and
 Unix-ms dates -> 400 (was silent-empty / unhandled 500).
- /summary: add updated_at (updated_from/to) filter; accept comma-separated multi-status (scalar still works).
- Swagger: array params with enums + example values; document /search dates as absolute Unix-ms and /summary dates as program-local Pacific.