### PR TITLE
feat(BCHEP-673): persist Sidekiq logs to a PVC, updated timeline view…

### DIFF
--- a/app/frontend/components/shared/energy-savings-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/energy-savings-applications/requirement-form.tsx
@@ -1,5 +1,5 @@
 import { Box, Center, Collapse, Flex, Link, Text, useDisclosure } from '@chakra-ui/react';
-import { CaretDown, CaretUp, Info } from '@phosphor-icons/react';
+import { CaretDown, CaretUp } from '@phosphor-icons/react';
 import { observer } from 'mobx-react-lite';
 
 import { format } from 'date-fns';
@@ -589,21 +589,23 @@ export const RequirementForm = observer(
                 px={4}
                 py={3}
                 align="center"
-                justify="space-between"
+                gap={2}
                 cursor="pointer"
                 onClick={onStatusToggle}
                 aria-expanded={isStatusOpen}
                 aria-controls="application-status-details"
               >
-                <Flex align="center" gap={2}>
-                  <Box color="semantic.info">
-                    <Info size={20} aria-hidden={true} />
-                  </Box>
-                  <Text fontWeight="semibold" fontSize="sm" mb={0}>
-                    {t('energySavingsApplication.show.applicationStatusTitle')}
+                <Box color="semantic.info">
+                  {isStatusOpen ? <CaretUp size={18} aria-hidden={true} /> : <CaretDown size={18} aria-hidden={true} />}
+                </Box>
+                {permitApplication?.updatedAt && (
+                  <Text mb={0}>
+                    {t('energySavingsApplication.show.applicationUpdated', {
+                      submissionType: permitApplication.submissionType.name,
+                      date: format(permitApplication.updatedAt, 'MMM d, yyyy h:mm a'),
+                    })}
                   </Text>
-                </Flex>
-                <Box color="semantic.info">{isStatusOpen ? <CaretUp size={18} /> : <CaretDown size={18} />}</Box>
+                )}
               </Flex>
               <Collapse in={isStatusOpen} animateOpacity>
                 <Box id="application-status-details" bg="semantic.infoLight" px={4} pb={4}>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -52,6 +52,10 @@ if Rails.env.production? && ENV["IS_DOCKER_BUILD"].blank? # skip this during pre
 
   Sidekiq.configure_server do |config|
     configure_sidekiq_server(config, redis_cfg, ENV["SIDEKIQ_CONCURRENCY"].to_i)
+    # Route Sidekiq's own logs (job lifecycle, heartbeat) through the Rails
+    # MultiLogger so they go to both STDOUT (Loki) and /app/log/application.log
+    # (PVC), matching the app pod's logging behaviour.
+    config.logger = Rails.logger
   end
 
   Sidekiq.configure_client do |config|
@@ -59,9 +63,11 @@ if Rails.env.production? && ENV["IS_DOCKER_BUILD"].blank? # skip this during pre
   end
 
   # Load cron schedule in production only
+  # load_from_hash! (bang) replaces ALL cron jobs atomically — removes stale Redis entries
+  # not in the YAML. load_from_hash (no bang) only adds/updates, leaving removed jobs alive.
   schedule_file = "config/sidekiq_cron_schedule.yml"
   if File.exist?(schedule_file)
-    Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+    Sidekiq::Cron::Job.load_from_hash! YAML.load_file(schedule_file)
   end
 elsif Rails.env.development?
   # Development configuration uses default Redis connection
@@ -72,6 +78,6 @@ elsif Rails.env.development?
   # Load cron schedule in development for testing
   schedule_file = "config/sidekiq_cron_schedule.yml"
   if File.exist?(schedule_file)
-    Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+    Sidekiq::Cron::Job.load_from_hash! YAML.load_file(schedule_file)
   end
 end

--- a/helm/_sidekiq/templates/deployment.yaml
+++ b/helm/_sidekiq/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- $deploymentTag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- $root := . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -108,13 +109,26 @@ spec:
           livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.volumeMounts }}
+          {{- if or .Values.volumeMounts .Values.logVolume.enabled }}
           volumeMounts:
+            {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.logVolume.enabled }}
+            - name: log-volume
+              mountPath: /app/log
+            {{- end }}
           {{- end }}
-      {{- with .Values.volumes }}
+      {{- if or .Values.volumes .Values.logVolume.enabled }}
       volumes:
+        {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if .Values.logVolume.enabled }}
+        - name: log-volume
+          persistentVolumeClaim:
+            claimName: {{ include "_.fullname" $root }}-log
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/_sidekiq/templates/logs-purge-cronjob.yaml
+++ b/helm/_sidekiq/templates/logs-purge-cronjob.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.logVolume.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "_.fullname" . }}-purge-logs
+spec:
+  schedule: "0 0 * * *"
+  successfulJobsHistoryLimit: 1  # Keep only last successful run (daily job)
+  failedJobsHistoryLimit: 1  # Keep only 1 failed Job
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 600  # Deletes Jobs and their pods 10 minutes after completion
+      template:
+        spec:
+          containers:
+            - name: 30-day-log-purger
+              image: alpine:3.21.3
+              command: ["/bin/sh"]
+              args:
+                - "-c"
+                - >
+                  echo "Starting log purge: $(date)";
+                  find /app/log -type f -mtime +30 -exec rm -v {} + &&
+                  echo "Log purge completed: $(date)";
+              volumeMounts:
+                - name: log-volume
+                  mountPath: /app/log
+              resources:
+                requests:
+                  memory: 64Mi
+                  cpu: 50m
+          restartPolicy: OnFailure
+          volumes:
+            - name: log-volume
+              persistentVolumeClaim:
+                claimName: {{ include "_.fullname" . }}-log
+{{- end }}

--- a/helm/_sidekiq/templates/pvc.yaml
+++ b/helm/_sidekiq/templates/pvc.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.logVolume.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "_.fullname" . }}-log
+  labels:
+    {{- include "_.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.logVolume.storage }}
+{{- end }}

--- a/helm/_sidekiq/values.yaml
+++ b/helm/_sidekiq/values.yaml
@@ -73,6 +73,10 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+logVolume:
+  enabled: false
+  storage: 512Mi
+
 volumes: []
 
 volumeMounts: []

--- a/helm/main/values.yaml
+++ b/helm/main/values.yaml
@@ -81,6 +81,9 @@ sidekiq:
   nameOverride: hesp-sidekiq
   fullnameOverride: hesp-sidekiq
 
+  logVolume:
+    enabled: true
+
   resources:
     requests:
       cpu: 300m


### PR DESCRIPTION
…, load_from_hash! (bang) added

Mirror the app chart's logVolume mechanism: hesp-sidekiq-log PVC mounted at /app/log with a 30-day purge cronjob, plus config.logger = Rails.logger so Sidekiq's own logs reach the file. App chart and production.rb untouched. Updated the Timeline view on the form page