### PR TITLE
feat(BCHEP-659):  add the confimration dialogs for onboarding withdra…

### DIFF
--- a/app/controllers/api/contractor_onboards_controller.rb
+++ b/app/controllers/api/contractor_onboards_controller.rb
@@ -26,7 +26,7 @@ class Api::ContractorOnboardsController < Api::ApplicationController
 
     # If this contractor already has an in-progress onboarding, return it instead of
     # creating a duplicate (guards against double-fire / multi-tab races).
-    existing = contractor.contractor_onboards.order(created_at: :desc).first
+    existing = contractor.latest_onboard
     if existing&.onboard_application&.draft?
       return(
         render json: ContractorOnboardBlueprint.render(existing), status: :ok

--- a/app/controllers/api/contractor_onboards_controller.rb
+++ b/app/controllers/api/contractor_onboards_controller.rb
@@ -15,13 +15,23 @@ class Api::ContractorOnboardsController < Api::ApplicationController
   def create
     program = Program.find_by!(slug: "energy-savings-program")
 
+    # Reuse the user's existing contractor if there is one (e.g. when restarting after a
+    # withdrawn onboarding); only create a new contractor for a first-time onboarding.
     contractor =
-      Contractor.create!(
-        contact: current_user,
-        business_name: "TBD",
-        onboarded: false
-      )
+      Contractor.find_or_create_by(contact: current_user) do |c|
+        c.business_name = "TBD"
+        c.onboarded = false
+      end
     contractor.reindex
+
+    # If this contractor already has an in-progress onboarding, return it instead of
+    # creating a duplicate (guards against double-fire / multi-tab races).
+    existing = contractor.contractor_onboards.order(created_at: :desc).first
+    if existing&.onboard_application&.draft?
+      return(
+        render json: ContractorOnboardBlueprint.render(existing), status: :ok
+      )
+    end
 
     # Create the Permit Aplication (Contractor Onboarding type)
     onboarding_form =

--- a/app/frontend/components/domains/energy-savings-application/edit-energy-savings-application-screen.tsx
+++ b/app/frontend/components/domains/energy-savings-application/edit-energy-savings-application-screen.tsx
@@ -140,7 +140,6 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
     try {
       const response = await currentPermitApplication.destroy();
       if (response.ok) {
-        onWithdrawlClose();
         return true;
       }
       return false;

--- a/app/frontend/components/domains/energy-savings-application/edit-energy-savings-application-screen.tsx
+++ b/app/frontend/components/domains/energy-savings-application/edit-energy-savings-application-screen.tsx
@@ -1,6 +1,5 @@
 import { Box, Button, Divider, Flex, Heading, HStack, Spacer, Stack, Text, useDisclosure } from '@chakra-ui/react';
-import { Phone } from '@phosphor-icons/react';
-import { CaretDown, CaretRight, CaretUp, FloppyDiskBack, Info, NotePencil, Warning } from '@phosphor-icons/react';
+import { CaretDown, CaretRight, CaretUp, FloppyDiskBack, NotePencil, Phone, Warning } from '@phosphor-icons/react';
 import { t } from 'i18next';
 import { observer } from 'mobx-react-lite';
 import * as R from 'ramda';
@@ -23,9 +22,9 @@ import { PermitApplicationSubmitModal } from '../../shared/energy-savings-applic
 import { RequirementForm } from '../../shared/energy-savings-applications/requirement-form';
 import { FloatingHelpDrawer } from '../../shared/floating-help-drawer';
 import SandboxHeader from '../../shared/sandbox/sandbox-header';
-import { ChecklistSideBar } from './checklist-sidebar';
 import { BlockCollaboratorAssignmentManagement } from './assignment-management/block-collaborator-assignment-management';
 import { useCollaborationAssignmentNodes } from './assignment-management/hooks/use-collaboration-assignment-nodes';
+import { ChecklistSideBar } from './checklist-sidebar';
 import { ContactSummaryModal } from './contact-summary-modal';
 import { RevisionSideBar } from './revision-sidebar';
 import { SubmissionDownloadModal } from './submission-download-modal';
@@ -142,7 +141,6 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
       const response = await currentPermitApplication.destroy();
       if (response.ok) {
         onWithdrawlClose();
-        navigate('/');
         return true;
       }
       return false;
@@ -228,6 +226,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
       navigate(`/applications/${currentPermitApplication?.id}/withdrawl-success`, {
         state: {
           submissionType: currentPermitApplication.submissionType.name,
+          isOnboarding: currentPermitApplication.isContractorOnboarding,
         },
       });
     }
@@ -502,9 +501,14 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
         headerText={t('energySavingsApplication.withdraw.confirmTitle', {
           submissionType: currentPermitApplication.submissionType.name.toLowerCase(),
         })}
-        bodyText={t('energySavingsApplication.withdraw.confirmMessage', {
-          submissionType: currentPermitApplication.submissionType.name.toLowerCase(),
-        })}
+        bodyText={t(
+          currentPermitApplication.isContractorOnboarding
+            ? 'energySavingsApplication.withdraw.confirmMessageOnboarding'
+            : 'energySavingsApplication.withdraw.confirmMessage',
+          {
+            submissionType: currentPermitApplication.submissionType.name.toLowerCase(),
+          },
+        )}
         confirmText={t('ui.confirm')}
         cancelText={t('ui.cancel')}
         closeOnOverlayClick={false}

--- a/app/frontend/components/domains/energy-savings-application/successful-action-screens.tsx
+++ b/app/frontend/components/domains/energy-savings-application/successful-action-screens.tsx
@@ -1,12 +1,12 @@
-import { Container, Flex, Heading, Icon, Text, VStack, Box, Button } from '@chakra-ui/react';
+import { Box, Button, Container, Flex, Heading, Icon, Text, VStack } from '@chakra-ui/react';
 import { CheckCircleIcon, WarningCircleIcon } from '@phosphor-icons/react';
-import { RouterLinkButton } from '../../shared/navigation/router-link-button';
 import { observer } from 'mobx-react-lite';
-import { useTranslation } from 'react-i18next';
-import { useLocation, useParams, useNavigate } from 'react-router-dom';
-import { useMst } from '../../../setup/root';
 import React, { useEffect } from 'react';
-import { EUserRoles, EPermitClassificationCode } from '../../../types/enums';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useMst } from '../../../setup/root';
+import { EPermitClassificationCode, EUserRoles } from '../../../types/enums';
+import { RouterLinkButton } from '../../shared/navigation/router-link-button';
 
 /***
  * Base Reusable Success Screen
@@ -111,12 +111,14 @@ export const SuccessfulActionScreen = ({
 export const SuccessfulWithdrawalScreen = observer(() => {
   const { t } = useTranslation();
   const location = useLocation();
-  const { submissionType } = location.state || {};
+  const { submissionType, isOnboarding } = location.state || {};
   const { userStore } = useMst();
   const currentUser = userStore.currentUser;
 
   const getReturnPath = () => {
     if (currentUser.isParticipant) return '/applications';
+    // A not-yet-onboarded contractor has no /contractor-dashboard; their home is the welcome page.
+    if (currentUser.isContractor && isOnboarding) return '/welcome/contractor';
     if (currentUser.isContractor) return '/contractor-dashboard';
     return '/submission-inbox';
   };
@@ -130,9 +132,11 @@ export const SuccessfulWithdrawalScreen = observer(() => {
       primaryButtonLabel={
         currentUser.isParticipant
           ? t('energySavingsApplication.returnToDashboard')
-          : currentUser.isContractor
-            ? t('contractor.invoiceSuccess.returnToDashboard')
-            : t('energySavingsApplication.new.viewAllSubmissions')
+          : currentUser.isContractor && isOnboarding
+            ? t('contractorOnboarding.returnToDashboard')
+            : currentUser.isContractor
+              ? t('contractor.invoiceSuccess.returnToDashboard')
+              : t('energySavingsApplication.new.viewAllSubmissions')
       }
       primaryButtonTo={getReturnPath()}
     />

--- a/app/frontend/components/domains/home/contractor-onboarding.tsx
+++ b/app/frontend/components/domains/home/contractor-onboarding.tsx
@@ -1,6 +1,6 @@
 import { Flex } from '@chakra-ui/react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { contractorOnboardingImportTokenKey } from '../../../constants';
 import { useSessionStorage } from '../../../hooks/use-session-state';
 import { useMst } from '../../../setup/root';
@@ -12,6 +12,7 @@ export const ContractorOnboardingScreen = ({ ...rest }: IContractorOnboardingScr
   const { permitApplicationStore, userStore, uiStore, contractorStore, sessionStore } = useMst();
   const { currentUser } = userStore;
   const navigate = useNavigate();
+  const location = useLocation();
   const [importToken, setImportToken] = useSessionStorage(contractorOnboardingImportTokenKey, null);
   const [importHandled, setImportHandled] = useState(false);
   const cancelledRef = useRef(false);
@@ -101,7 +102,7 @@ export const ContractorOnboardingScreen = ({ ...rest }: IContractorOnboardingScr
       if (!onboarding) {
         // Contractor exists but has no onboarding (e.g. a previous draft was withdrawn/deleted).
         // Let them restart: create a fresh onboarding for the existing contractor.
-        onboarding = await contractorStore.createOnboarding(contractor.id);
+        onboarding = await contractorStore.createOnboarding(currentUser.id);
         if (cancelledRef.current) return;
         if (onboarding) {
           navigate(`/applications/${onboarding.permitApplicationId}/edit`);

--- a/app/frontend/components/domains/home/contractor-onboarding.tsx
+++ b/app/frontend/components/domains/home/contractor-onboarding.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useCallback, useState, useRef } from 'react';
-import { useMst } from '../../../setup/root';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { SharedSpinner } from '../../shared/base/shared-spinner';
 import { Flex } from '@chakra-ui/react';
-import { useSessionStorage } from '../../../hooks/use-session-state';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { contractorOnboardingImportTokenKey } from '../../../constants';
+import { useSessionStorage } from '../../../hooks/use-session-state';
+import { useMst } from '../../../setup/root';
+import { SharedSpinner } from '../../shared/base/shared-spinner';
 
 interface IContractorOnboardingScreenProps {}
 
@@ -90,7 +90,7 @@ export const ContractorOnboardingScreen = ({ ...rest }: IContractorOnboardingScr
         if (onboarding) {
           navigate(`/applications/${onboarding.permitApplicationId}/edit`);
         } else {
-          navigate('/welcome');
+          navigate('/welcome/contractor');
         }
         return;
       }
@@ -99,10 +99,15 @@ export const ContractorOnboardingScreen = ({ ...rest }: IContractorOnboardingScr
       onboarding = await contractorStore.fetchOnboarding(contractor.id);
       if (cancelledRef.current) return;
       if (!onboarding) {
-        // if we got here it means we have a contractor but their onboarding is gone "withdrawn?"
-        // should we even allow withdrawn?
-        console.error('No onboarding found; why didnt we create one or was it withdrawn?');
-
+        // Contractor exists but has no onboarding (e.g. a previous draft was withdrawn/deleted).
+        // Let them restart: create a fresh onboarding for the existing contractor.
+        onboarding = await contractorStore.createOnboarding(contractor.id);
+        if (cancelledRef.current) return;
+        if (onboarding) {
+          navigate(`/applications/${onboarding.permitApplicationId}/edit`);
+        } else {
+          navigate('/welcome/contractor');
+        }
         return;
       }
 

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1364,6 +1364,8 @@ const options = {
           withdraw: {
             confirmTitle: 'Are you sure you want to withdraw this {{submissionType}} form?',
             confirmMessage: 'By withdrawing this {{submissionType}} form your draft will not be saved.',
+            confirmMessageOnboarding:
+              'If you withdraw, your draft will not be saved. You can restart the onboarding process if you decide to register in future.',
             confirm: 'Withdraw application',
             success: {
               title: 'Your {{submissionType}} form has been withdrawn.',


### PR DESCRIPTION
…wl and let contractors with an existing accont restart if the form is withdrawn

- Onboarding-specific withdrawal modal copy (confirmMessageOnboarding); participants keep the generic message
- Show the withdrawal success page reliably by removing the stray navigate('/'); "Back to Contractor homepage" routes to /welcome/contractor
- Restart onboarding after withdrawal instead of dead-ending on login; reuse the contractor (find_or_create) and guard against duplicate onboardings