### PR TITLE
feat(BCHEP-669): show ineligible reason on the application/invoice page

### DIFF
--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -47,7 +47,8 @@ class PermitApplicationBlueprint < Blueprinter::Base
            :resubmitted_at,
            :screened_in_at,
            :revisions_requested_at,
-           :missing_pdfs
+           :missing_pdfs,
+           :status_update_reason
     association :submission_type,
                 blueprint: PermitClassificationBlueprint,
                 view: :base

--- a/app/frontend/components/shared/energy-savings-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/energy-savings-applications/requirement-form.tsx
@@ -118,7 +118,7 @@ export const RequirementForm = observer(
       const latestSR = permitApplication.latestSubmittedSupportRequestWithDocuments;
       const statuses = [];
 
-      if (permitApplication.isSubmitted || permitApplication.isInReview) {
+      if (!permitApplication.isDraft) {
         statuses.push({
           label: t('energySavingsApplication.show.applicationCreated', {
             submissionType: permitApplication?.submissionType.name,
@@ -553,33 +553,6 @@ export const RequirementForm = observer(
             ) : (
               <SharedSpinner position="fixed" right={24} top="50vh" zIndex={12} />
             ))}
-          {permitApplication?.isRevisionsRequested && permitApplication?.revisionsRequestedAt && (
-            <CustomMessageBox
-              description={t('energySavingsApplication.show.revisionsWereRequested', {
-                date: format(permitApplication.revisionsRequestedAt, 'MMM d, yyyy h:mm a'),
-              })}
-              status="warning"
-            />
-          )}
-          {formattedSupportRequestDate && isAdminUser && (
-            <CustomMessageBox
-              description={t('energySavingsApplication.show.supportingFilesRequest.requestedText', {
-                date: formattedSupportRequestDate,
-              })}
-              status="warning"
-            />
-          )}
-          {/* {permitApplication?.isSubmitted ||
-            (permitApplication?.isInReview && (
-              <CustomMessageBox
-                description={t('energySavingsApplication.show.applicationSubmitted', {
-                  date: permitApplication?.submittedAt
-                    ? format(new Date(permitApplication.submittedAt), 'MMM d, yyyy h:mm a')
-                    : '',
-                })}
-                status="info"
-              />
-            ))} */}
           {infoStatusItems.length > 0 && (
             <Box border="1px solid" borderColor="semantic.info" borderRadius="lg" overflow="hidden">
               <Flex
@@ -618,6 +591,45 @@ export const RequirementForm = observer(
               </Collapse>
             </Box>
           )}
+          {permitApplication?.isIneligible && (
+            <CustomMessageBox
+              description={
+                permitApplication?.statusUpdateReason
+                  ? `${t('energySavingsApplication.show.ineligibleReasonShort')} ${permitApplication.statusUpdateReason}`
+                  : t('energySavingsApplication.show.inEligibleDetails', {
+                      submissionType: permitApplication?.submissionType?.name?.toLowerCase(),
+                    })
+              }
+              status="error"
+            />
+          )}
+          {permitApplication?.isRevisionsRequested && permitApplication?.revisionsRequestedAt && (
+            <CustomMessageBox
+              description={t('energySavingsApplication.show.revisionsWereRequested', {
+                date: format(permitApplication.revisionsRequestedAt, 'MMM d, yyyy h:mm a'),
+              })}
+              status="warning"
+            />
+          )}
+          {formattedSupportRequestDate && isAdminUser && (
+            <CustomMessageBox
+              description={t('energySavingsApplication.show.supportingFilesRequest.requestedText', {
+                date: formattedSupportRequestDate,
+              })}
+              status="warning"
+            />
+          )}
+          {/* {permitApplication?.isSubmitted ||
+            (permitApplication?.isInReview && (
+              <CustomMessageBox
+                description={t('energySavingsApplication.show.applicationSubmitted', {
+                  date: permitApplication?.submittedAt
+                    ? format(new Date(permitApplication.submittedAt), 'MMM d, yyyy h:mm a')
+                    : '',
+                })}
+                status="info"
+              />
+            ))} */}
           <Text fontSize="sm" mb={0}>
             {t('site.formSupportContact')}{' '}
             <Link

--- a/app/frontend/components/shared/energy-savings-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/energy-savings-applications/requirement-form.tsx
@@ -595,7 +595,7 @@ export const RequirementForm = observer(
             <CustomMessageBox
               description={
                 permitApplication?.statusUpdateReason
-                  ? `${t('energySavingsApplication.show.ineligibleReasonShort')} ${permitApplication.statusUpdateReason}`
+                  ? `${t('energySavingsApplication.show.inEligibleReasonShort')} ${permitApplication.statusUpdateReason}`
                   : t('energySavingsApplication.show.inEligibleDetails', {
                       submissionType: permitApplication?.submissionType?.name?.toLowerCase(),
                     })

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1476,6 +1476,7 @@ const options = {
             inEligibleDetails: 'Ineligible {{submissionType}} form details',
             applicationId: 'Reference # is #',
             inEligibleReason: 'Reason this {{submissionType}} form is ineligible:',
+            ineligibleReasonShort: 'Ineligible reason:',
             revision: {
               newRevision: 'New revision',
               pastRequests: 'Past requests',

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1476,7 +1476,7 @@ const options = {
             inEligibleDetails: 'Ineligible {{submissionType}} form details',
             applicationId: 'Reference # is #',
             inEligibleReason: 'Reason this {{submissionType}} form is ineligible:',
-            ineligibleReasonShort: 'Ineligible reason:',
+            inEligibleReasonShort: 'Ineligible reason:',
             revision: {
               newRevision: 'New revision',
               pastRequests: 'Past requests',

--- a/app/frontend/models/energy-savings-application.ts
+++ b/app/frontend/models/energy-savings-application.ts
@@ -97,6 +97,7 @@ export const EnergySavingsApplicationModel = types.snapshotProcessor(
       supportingDocuments: types.maybeNull(types.frozen<IDownloadableFile[]>()),
       allSubmissionVersionCompletedSupportingDocuments: types.maybeNull(types.frozen<IDownloadableFile[]>()),
       referenceNumber: types.maybeNull(types.string),
+      statusUpdateReason: types.maybeNull(types.string),
       missingPdfs: types.maybeNull(types.array(types.string)),
       isFullyLoaded: types.optional(types.boolean, false),
       isDirty: types.optional(types.boolean, false),


### PR DESCRIPTION
- Expose status_update_reason in the PermitApplicationBlueprint :base view
- Add statusUpdateReason to the EnergySavingsApplicationModel
- Show the reason inline via CustomMessageBox when isIneligible, next to the existing revisions-requested/support-request messages
- Fix the status timeline to render for any non-draft status (was gated to submitted/inReview only) and moved it above the messages