### PR TITLE
fix(BCHEP-466): allow re-inviting a pending employee from Invite Empl…

### DIFF
--- a/app/services/contractor_employee_inviter.rb
+++ b/app/services/contractor_employee_inviter.rb
@@ -27,26 +27,40 @@ class ContractorEmployeeInviter
     role = user_params[:role]&.to_sym || :contractor
 
     user = User.find_by(email: email)
+    return invite_new_user(email, name, role) unless user.present?
 
-    if user.present?
-      contractor_employee = employee_exists?(user)
-      return handle_email_taken(user) if contractor_employee
+    existing_membership =
+      contractor.contractor_employees.find_by(employee: user)
 
-      # Only reinvite if user is not discarded
-      if !user.discarded?
-        reinvite_user(user, role)
-      else
-        # User exists but is deactivated and not yet a contractor employee - don't allow invite
-        results[:email_taken_deactivated] << user
-      end
+    if existing_membership.present?
+      handle_existing_contractor_employee(user)
+    elsif employee_exists_elsewhere?(user)
+      handle_email_taken(user)
+    elsif !user.discarded?
+      reinvite_user(user, role)
     else
-      invite_new_user(email, name, role)
+      # User exists but is deactivated and not yet a contractor employee - don't allow invite
+      results[:email_taken_deactivated] << user
     end
   end
 
-  def employee_exists?(user)
+  def employee_exists_elsewhere?(user)
     ContractorEmployee.exists?(employee: user) ||
       Contractor.exists?(contact_id: user.id)
+  end
+
+  # User is already a ContractorEmployee of this contractor - resend the
+  # invite if pending, rather than reporting it as "taken" (matches the
+  # single-employee reinvite action's behavior).
+  def handle_existing_contractor_employee(user)
+    if user.discarded?
+      results[:email_taken_deactivated] << user
+    elsif user.invitation_sent_at.present? && user.invitation_accepted_at.nil?
+      user.invite!(invited_by, invitation_options)
+      results[:reinvited] << user
+    else
+      results[:email_taken_active] << user
+    end
   end
 
   def handle_email_taken(user)

--- a/spec/controllers/contractor_employees_controller_spec.rb
+++ b/spec/controllers/contractor_employees_controller_spec.rb
@@ -1,0 +1,467 @@
+# spec/controllers/api/contractor_employees_controller_spec.rb
+require "rails_helper"
+
+RSpec.describe Api::ContractorEmployeesController, type: :controller do
+  # Create test users with different roles
+  let(:admin_user) do
+    User.create!(
+      first_name: "Admin",
+      last_name: "User",
+      email: "admin@example.com",
+      password: "P@ssword1",
+      role: :admin,
+      confirmed_at: Time.current
+    )
+  end
+
+  let(:participant_user) do
+    User.create!(
+      first_name: "Participant",
+      last_name: "User",
+      email: "participant@example.com",
+      password: "P@ssword1",
+      role: :participant,
+      confirmed_at: Time.current
+    )
+  end
+
+  # Create contractor and employees
+  let(:contractor) do
+    Contractor.create!(
+      business_name: "Test Contractor Ltd",
+      contact: admin_user
+    )
+  end
+
+  let(:active_employee) do
+    user =
+      User.create!(
+        first_name: "Active",
+        last_name: "Employee",
+        email: "active@example.com",
+        password: "P@ssword1",
+        reviewed: true,
+        discarded_at: nil,
+        invitation_accepted_at: Time.current,
+        confirmed_at: Time.current
+      )
+    ContractorEmployee.create!(contractor: contractor, employee: user)
+    user
+  end
+
+  let(:deactivated_employee) do
+    user =
+      User.create!(
+        first_name: "Deactivated",
+        last_name: "Employee",
+        email: "deactivated@example.com",
+        password: "P@ssword1",
+        reviewed: true,
+        discarded_at: Time.current,
+        invitation_accepted_at: Time.current,
+        confirmed_at: Time.current
+      )
+    ContractorEmployee.create!(contractor: contractor, employee: user)
+    user
+  end
+
+  let(:pending_employee) do
+    user =
+      User.create!(
+        first_name: "Pending",
+        last_name: "Employee",
+        email: "pending@example.com",
+        password: "P@ssword1",
+        reviewed: false,
+        discarded_at: nil,
+        invitation_sent_at: Time.current,
+        invitation_accepted_at: nil,
+        invitation_token: "test_token_123",
+        confirmed_at: Time.current
+      )
+    ContractorEmployee.create!(contractor: contractor, employee: user)
+    user
+  end
+
+  let(:program) { create(:program) }
+
+  # Helper method to parse JSON responses
+  def json_response
+    JSON.parse(response.body)
+  end
+
+  # Sign in as admin for most tests
+  before { sign_in admin_user }
+
+  describe "POST #deactivate" do
+    context "when user is authorized (admin)" do
+      it "deactivates an active employee" do
+        post :deactivate,
+             params: {
+               contractor_id: contractor.id,
+               id: active_employee.id
+             }
+
+        expect(response).to have_http_status(:success)
+        expect(json_response["meta"]["message"]["type"]).to eq("success")
+        expect(json_response["meta"]["message"]["message"]).to include(
+          "deactivated"
+        )
+        expect(active_employee.reload.discarded_at).to be_present
+      end
+
+      it "is idempotent - can deactivate already deactivated employee" do
+        post :deactivate,
+             params: {
+               contractor_id: contractor.id,
+               id: deactivated_employee.id
+             }
+
+        expect(response).to have_http_status(:success)
+        expect(deactivated_employee.reload.discarded_at).to be_present
+      end
+    end
+
+    context "when user is unauthorized (participant)" do
+      before { sign_in participant_user }
+
+      it "returns 403 forbidden" do
+        post :deactivate,
+             params: {
+               contractor_id: contractor.id,
+               id: active_employee.id
+             }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when employee does not belong to contractor" do
+      let(:other_contractor) do
+        Contractor.create!(
+          business_name: "Other Contractor Ltd",
+          contact: admin_user
+        )
+      end
+
+      let(:other_employee) do
+        user =
+          User.create!(
+            first_name: "Other",
+            last_name: "Employee",
+            email: "other@example.com",
+            password: "P@ssword1",
+            confirmed_at: Time.current
+          )
+        ContractorEmployee.create!(contractor: other_contractor, employee: user)
+        user
+      end
+
+      it "raises RecordNotFound" do
+        expect {
+          post :deactivate,
+               params: {
+                 contractor_id: contractor.id,
+                 id: other_employee.id
+               }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  describe "POST #reactivate" do
+    context "when user is authorized (admin)" do
+      it "reactivates a deactivated employee" do
+        post :reactivate,
+             params: {
+               contractor_id: contractor.id,
+               id: deactivated_employee.id
+             }
+
+        expect(response).to have_http_status(:success)
+        expect(json_response["meta"]["message"]["type"]).to eq("success")
+        expect(deactivated_employee.reload.discarded_at).to be_nil
+      end
+
+      it "is idempotent - can reactivate already active employee" do
+        post :reactivate,
+             params: {
+               contractor_id: contractor.id,
+               id: active_employee.id
+             }
+
+        expect(response).to have_http_status(:success)
+        expect(active_employee.reload.discarded_at).to be_nil
+      end
+    end
+
+    context "when user is unauthorized (participant)" do
+      before { sign_in participant_user }
+
+      it "returns 403 forbidden" do
+        post :reactivate,
+             params: {
+               contractor_id: contractor.id,
+               id: deactivated_employee.id
+             }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "POST #invite" do
+    context "when user is authorized (admin)" do
+      it "resends the invite and reports it under reinvited when the email is already pending for this contractor" do
+        original_sent_at = pending_employee.invitation_sent_at
+        sleep 0.1 # Ensure timestamp difference
+
+        post :invite,
+             params: {
+               contractor_id: contractor.id,
+               program_id: program.id,
+               users: [
+                 {
+                   email: pending_employee.email,
+                   name: "Pending Employee",
+                   role: "contractor"
+                 }
+               ]
+             }
+
+        expect(response).to have_http_status(:success)
+        expect(
+          json_response["data"]["reinvited"].map { |u| u["email"] }
+        ).to include(pending_employee.email)
+        expect(pending_employee.reload.invitation_sent_at).to be >
+          original_sent_at
+      end
+
+      it "reports email_taken_active when the email already belongs to an active employee of this contractor" do
+        post :invite,
+             params: {
+               contractor_id: contractor.id,
+               program_id: program.id,
+               users: [
+                 {
+                   email: active_employee.email,
+                   name: "Active Employee",
+                   role: "contractor"
+                 }
+               ]
+             }
+
+        expect(response).to have_http_status(:success)
+        expect(
+          json_response["data"]["email_taken_active"].map { |u| u["email"] }
+        ).to include(active_employee.email)
+      end
+    end
+
+    context "when user is unauthorized (participant)" do
+      before { sign_in participant_user }
+
+      it "returns 403 forbidden" do
+        post :invite,
+             params: {
+               contractor_id: contractor.id,
+               program_id: program.id,
+               users: [
+                 {
+                   email: "new-employee@example.com",
+                   name: "New Employee",
+                   role: "contractor"
+                 }
+               ]
+             }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "POST #reinvite" do
+    context "when user is authorized (admin)" do
+      it "re-invites a pending employee" do
+        original_sent_at = pending_employee.invitation_sent_at
+        sleep 0.1 # Ensure timestamp difference
+
+        post :reinvite,
+             params: {
+               contractor_id: contractor.id,
+               id: pending_employee.id,
+               program_id: program.id
+             }
+
+        expect(response).to have_http_status(:success)
+        expect(json_response["meta"]["message"]["type"]).to eq("success")
+        expect(pending_employee.reload.invitation_sent_at).to be >
+          original_sent_at
+        expect(pending_employee.invitation_token).to be_present
+      end
+
+      it "raises RecordNotFound when employee does not exist" do
+        expect {
+          post :reinvite,
+               params: {
+                 contractor_id: contractor.id,
+                 id: "00000000-0000-0000-0000-000000000000"
+               }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when user is unauthorized (participant)" do
+      before { sign_in participant_user }
+
+      it "returns 403 forbidden" do
+        post :reinvite,
+             params: {
+               contractor_id: contractor.id,
+               id: pending_employee.id
+             }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "POST #revoke_invite" do
+    context "when user is authorized (admin)" do
+      it "revokes a pending invitation" do
+        expect(pending_employee.invitation_token).to be_present
+        pending_employee_id = pending_employee.id
+
+        post :revoke_invite,
+             params: {
+               contractor_id: contractor.id,
+               id: pending_employee_id
+             }
+
+        expect(response).to have_http_status(:success)
+        expect(json_response["meta"]["message"]["type"]).to eq("success")
+        expect(
+          ContractorEmployee.exists?(employee_id: pending_employee_id)
+        ).to be false
+        # pending_employee has no other associations, so revoking deletes the orphaned user entirely
+        expect(User.exists?(pending_employee_id)).to be false
+      end
+
+      it "returns 422 when employee has no pending invite" do
+        post :revoke_invite,
+             params: {
+               contractor_id: contractor.id,
+               id: active_employee.id
+             }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_response["meta"]["message"]["type"]).to eq("error")
+      end
+
+      it "returns 422 when invitation already revoked" do
+        pending_employee.update(invitation_token: nil)
+
+        post :revoke_invite,
+             params: {
+               contractor_id: contractor.id,
+               id: pending_employee.id
+             }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when user is unauthorized (participant)" do
+      before { sign_in participant_user }
+
+      it "returns 403 forbidden" do
+        post :revoke_invite,
+             params: {
+               contractor_id: contractor.id,
+               id: pending_employee.id
+             }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "State Transitions" do
+    it "allows complete state transition cycle: active -> deactivated -> active" do
+      employee = active_employee
+
+      # Active -> Deactivated
+      post :deactivate,
+           params: {
+             contractor_id: contractor.id,
+             id: employee.id
+           }
+      expect(response).to have_http_status(:success)
+      expect(employee.reload.discarded_at).to be_present
+
+      # Deactivated -> Active
+      post :reactivate,
+           params: {
+             contractor_id: contractor.id,
+             id: employee.id
+           }
+      expect(response).to have_http_status(:success)
+      expect(employee.reload.discarded_at).to be_nil
+    end
+
+    it "allows multiple reinvites for pending employees" do
+      employee = pending_employee
+
+      3.times do
+        sleep 0.1
+        original_sent_at = employee.invitation_sent_at
+
+        post :reinvite,
+             params: {
+               contractor_id: contractor.id,
+               id: employee.id,
+               program_id: program.id
+             }
+        expect(response).to have_http_status(:success)
+        expect(employee.reload.invitation_sent_at).to be > original_sent_at
+      end
+    end
+
+    it "removes the contractor employee association on revoke, so a later reinvite 404s" do
+      employee_id = pending_employee.id
+
+      # Revoke - destroys the ContractorEmployee association (and the orphaned user, here)
+      post :revoke_invite,
+           params: {
+             contractor_id: contractor.id,
+             id: employee_id
+           }
+      expect(response).to have_http_status(:success)
+
+      # Reinvite - no ContractorEmployee association left for this contractor to look up
+      expect {
+        post :reinvite,
+             params: {
+               contractor_id: contractor.id,
+               id: employee_id,
+               program_id: program.id
+             }
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  describe "Authorization Levels" do
+    context "admin (reviewer)" do
+      before { sign_in admin_user }
+
+      it "can deactivate employees" do
+        post :deactivate,
+             params: {
+               contractor_id: contractor.id,
+               id: active_employee.id
+             }
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+end

--- a/spec/controllers/contractor_employees_controller_spec.rb
+++ b/spec/controllers/contractor_employees_controller_spec.rb
@@ -213,8 +213,8 @@ RSpec.describe Api::ContractorEmployeesController, type: :controller do
   describe "POST #invite" do
     context "when user is authorized (admin)" do
       it "resends the invite and reports it under reinvited when the email is already pending for this contractor" do
+        pending_employee.update!(invitation_sent_at: 1.hour.ago)
         original_sent_at = pending_employee.invitation_sent_at
-        sleep 0.1 # Ensure timestamp difference
 
         post :invite,
              params: {
@@ -283,8 +283,8 @@ RSpec.describe Api::ContractorEmployeesController, type: :controller do
   describe "POST #reinvite" do
     context "when user is authorized (admin)" do
       it "re-invites a pending employee" do
+        pending_employee.update!(invitation_sent_at: 1.hour.ago)
         original_sent_at = pending_employee.invitation_sent_at
-        sleep 0.1 # Ensure timestamp difference
 
         post :reinvite,
              params: {
@@ -413,7 +413,7 @@ RSpec.describe Api::ContractorEmployeesController, type: :controller do
       employee = pending_employee
 
       3.times do
-        sleep 0.1
+        employee.update!(invitation_sent_at: 1.hour.ago)
         original_sent_at = employee.invitation_sent_at
 
         post :reinvite,

--- a/spec/services/contractor_employee_inviter_spec.rb
+++ b/spec/services/contractor_employee_inviter_spec.rb
@@ -1,0 +1,145 @@
+require "rails_helper"
+
+RSpec.describe ContractorEmployeeInviter do
+  let(:admin_user) do
+    User.create!(
+      first_name: "Admin",
+      last_name: "User",
+      email: "admin@example.com",
+      password: "P@ssword1",
+      role: :admin,
+      confirmed_at: Time.current
+    )
+  end
+
+  let(:contractor) do
+    Contractor.create!(
+      business_name: "Test Contractor Ltd",
+      contact: admin_user
+    )
+  end
+
+  let(:other_contractor) do
+    Contractor.create!(
+      business_name: "Other Contractor Ltd",
+      contact: admin_user
+    )
+  end
+
+  let(:program) { create(:program) }
+
+  let(:inviter) do
+    described_class.new(
+      contractor: contractor,
+      program: program,
+      invited_by: admin_user
+    )
+  end
+
+  def invite(email)
+    inviter.invite_employees(
+      [{ email: email, name: "Some Employee", role: "contractor" }]
+    )
+  end
+
+  describe "#invite_employees" do
+    it "invites a brand-new email" do
+      results = invite("new-employee@example.com")
+
+      expect(results[:invited].map(&:email)).to contain_exactly(
+        "new-employee@example.com"
+      )
+    end
+
+    it "resends the invite when the email is already pending for this contractor" do
+      pending_employee =
+        User.create!(
+          first_name: "Pending",
+          last_name: "Employee",
+          email: "pending@example.com",
+          password: "P@ssword1",
+          invitation_sent_at: 1.day.ago,
+          invitation_accepted_at: nil,
+          invitation_token: "test_token_123",
+          confirmed_at: Time.current
+        )
+      ContractorEmployee.create!(
+        contractor: contractor,
+        employee: pending_employee
+      )
+      original_sent_at = pending_employee.invitation_sent_at
+
+      results = invite("pending@example.com")
+
+      expect(results[:reinvited]).to eq([pending_employee])
+      expect(results[:email_taken_pending]).to be_empty
+      expect(pending_employee.reload.invitation_sent_at).to be >
+        original_sent_at
+    end
+
+    it "reports email_taken_active when the email is already an active employee of this contractor" do
+      active_employee =
+        User.create!(
+          first_name: "Active",
+          last_name: "Employee",
+          email: "active@example.com",
+          password: "P@ssword1",
+          invitation_accepted_at: Time.current,
+          confirmed_at: Time.current
+        )
+      ContractorEmployee.create!(
+        contractor: contractor,
+        employee: active_employee
+      )
+
+      results = invite("active@example.com")
+
+      expect(results[:email_taken_active]).to eq([active_employee])
+      expect(results[:reinvited]).to be_empty
+    end
+
+    it "reports email_taken_deactivated when the email is a deactivated employee of this contractor" do
+      deactivated_employee =
+        User.create!(
+          first_name: "Deactivated",
+          last_name: "Employee",
+          email: "deactivated@example.com",
+          password: "P@ssword1",
+          discarded_at: Time.current,
+          invitation_accepted_at: Time.current,
+          confirmed_at: Time.current
+        )
+      ContractorEmployee.create!(
+        contractor: contractor,
+        employee: deactivated_employee
+      )
+
+      results = invite("deactivated@example.com")
+
+      expect(results[:email_taken_deactivated]).to eq([deactivated_employee])
+    end
+
+    it "reports email_taken_pending when the email is pending for a different contractor" do
+      other_contractor_pending =
+        User.create!(
+          first_name: "Other",
+          last_name: "Pending",
+          email: "other-pending@example.com",
+          password: "P@ssword1",
+          invitation_sent_at: 1.day.ago,
+          invitation_accepted_at: nil,
+          invitation_token: "test_token_456",
+          confirmed_at: Time.current
+        )
+      ContractorEmployee.create!(
+        contractor: other_contractor,
+        employee: other_contractor_pending
+      )
+
+      results = invite("other-pending@example.com")
+
+      expect(results[:email_taken_pending]).to eq([other_contractor_pending])
+      expect(results[:reinvited]).to be_empty
+    end
+  end
+end

--- a/spec/services/contractor_employee_inviter_spec.rb
+++ b/spec/services/contractor_employee_inviter_spec.rb
@@ -77,6 +77,33 @@ RSpec.describe ContractorEmployeeInviter do
         original_sent_at
     end
 
+    it "ensures a ProgramMembership exists when reinviting a pending employee whose membership is missing" do
+      pending_employee =
+        User.create!(
+          first_name: "Pending",
+          last_name: "Employee",
+          email: "pending@example.com",
+          password: "P@ssword1",
+          invitation_sent_at: 1.day.ago,
+          invitation_accepted_at: nil,
+          invitation_token: "test_token_123",
+          confirmed_at: Time.current
+        )
+      ContractorEmployee.create!(
+        contractor: contractor,
+        employee: pending_employee
+      )
+      expect(
+        ProgramMembership.exists?(user: pending_employee, program: program)
+      ).to be false
+
+      invite("pending@example.com")
+
+      expect(
+        ProgramMembership.exists?(user: pending_employee, program: program)
+      ).to be true
+    end
+
     it "reports email_taken_active when the email is already an active employee of this contractor" do
       active_employee =
         User.create!(


### PR DESCRIPTION
…oyees screen

Adds spec coverage for ContractorEmployeeInviter and the invite controller action; also fixes two pre-existing controller specs that were broken by unrelated prior changes.