### PR TITLE
fix(BCHEP-712): Add contractor and contractor employee EULA content a…

### DIFF
--- a/app/frontend/components/shared/editor/quill.css
+++ b/app/frontend/components/shared/editor/quill.css
@@ -1,7 +1,9 @@
-/* Update version if react-quill or quill-mention packages are upgraded */
-@import url("https://unpkg.com/react-quill@2.0.0/dist/quill.snow.css");
-@import url("https://unpkg.com/react-quill@2.0.0/dist/quill.bubble.css");
-@import url("https://unpkg.com/quill-mention@3.1.0/dist/quill.mention.css");
+/* CSS is imported from the installed `quill` package itself (not react-quill's
+   bundle) so it always matches the Quill version actually running - react-quill
+   still declares "quill": "^1.3.7", so its own published CSS is stale relative
+   to the "quill": "2.0.2" this app resolves via package.json override */
+@import 'quill/dist/quill.snow.css';
+@import 'quill/dist/quill.bubble.css';
 
 .ql-container {
   font-family: inherit;

--- a/app/frontend/components/shared/editor/quill.css
+++ b/app/frontend/components/shared/editor/quill.css
@@ -1,7 +1,9 @@
-/* CSS is imported from the installed `quill` package itself (not react-quill's
-   bundle) so it always matches the Quill version actually running - react-quill
-   still declares "quill": "^1.3.7", so its own published CSS is stale relative
-   to the "quill": "2.0.2" this app resolves via package.json override */
+/* CSS is imported from the installed `quill` package itself so it always
+   matches the Quill version actually running (pinned to "2.0.2" via the
+   package.json override below). Previously this imported react-quill's
+   published CSS bundle via CDN, which was stale (built against quill@^1.3.7)
+   and caused bullet lists to render as numbered lists. react-quill has since
+   been removed from this app entirely. */
 @import 'quill/dist/quill.snow.css';
 @import 'quill/dist/quill.bubble.css';
 

--- a/app/frontend/components/shared/editor/quill.css
+++ b/app/frontend/components/shared/editor/quill.css
@@ -1,6 +1,6 @@
 /* CSS is imported from the installed `quill` package itself so it always
    matches the Quill version actually running (pinned to "2.0.2" via the
-   package.json override below). Previously this imported react-quill's
+   root package.json's "overrides" entry). Previously this imported react-quill's
    published CSS bundle via CDN, which was stale (built against quill@^1.3.7)
    and caused bullet lists to render as numbered lists. react-quill has since
    been removed from this app entirely. */

--- a/app/frontend/components/shared/editor/savable-editor.tsx
+++ b/app/frontend/components/shared/editor/savable-editor.tsx
@@ -1,11 +1,10 @@
 import { Box, Button } from '@chakra-ui/react';
 import React, { useState } from 'react';
-import ReactQuill from 'react-quill';
-import 'react-quill/dist/quill.snow.css'; // Include the quill.snow.css stylesheet
+import { Editor } from './editor';
 
 /**
- * @deprecated This component is currently unused and relies on ReactQuill.
- * Do not use for new development; prefer the native Quill-based Editor component.
+ * @deprecated This component is currently unused.
+ * Do not use for new development; prefer the native Quill-based Editor component directly.
  */
 // Define your component's props and state as needed
 interface IProps {
@@ -30,7 +29,7 @@ const SavableEditor: React.FC<IProps> = ({ initialValue, onSave }) => {
 
   return (
     <Box>
-      <ReactQuill theme="snow" value={value} onChange={handleOnChange} />
+      <Editor htmlValue={value} onChange={handleOnChange} />
       {isDirty && (
         <Button onClick={handleSave} mt={3}>
           Save

--- a/db/migrate/20260710020000_reseed_contractor_eulas.rb
+++ b/db/migrate/20260710020000_reseed_contractor_eulas.rb
@@ -1,0 +1,5 @@
+class ReseedContractorEulas < ActiveRecord::Migration[7.1]
+  def change
+    EulaUpdater.run
+  end
+end

--- a/eulas/contractor.html
+++ b/eulas/contractor.html
@@ -1,43 +1,28 @@
 <div>
-  <p>
-    <b>Declaration and Consent</b>
-  </p>
+  <p><b>Declaration and consent</b></p>
 
   <p>
-    Participation in the Energy Savings Program (the "Program") requires you to agree to the Participant Terms and Conditions and Rebate Eligibility Requirements. Participation in the Energy Savings Program (the "Program") may involve one or more separate offers (each an "Offer"). Each Offer is governed by its own Participant Terms and Conditions and Rebate Eligibility Requirements.
+    Participation in the CleanBC Better Homes Energy Savings Program (the "Program") requires a contractor to agree to:
   </p>
 
   <ul>
     <li>
-      CleanBC Better Homes Energy Savings Program <a href="https://www.betterhomesbc.ca/esp-participant-terms-ground-oriented-PDF">Participant Terms &amp; Conditions</a> &amp; <a href="https://www.betterhomesbc.ca/esp-requirements-ground-oriented-PDF">Rebate Eligibility Requirements</a>
+      <a href="https://betterhomesbc.ca/esp-contractor-terms-ground-oriented-pdf">Contractor Terms and Conditions</a>
     </li>
     <li>
-      CleanBC Better Homes Energy Savings Program Condo and Apartment Rebate <a href="https://www.betterhomesbc.ca/esp-participant-terms-condo-and-apartment-PDF">Participant Terms &amp; Conditions</a> &amp; <a href="https://www.betterhomesbc.ca/esp-requirements-condo-and-apartment-PDF">Rebate Eligibility Requirements</a>
+      <a href="https://betterhomesbc.ca/learn-about-programs/energy-savings-program/energy-savings-program-requirements/">Rebate Eligibility Requirements</a>
     </li>
   </ul>
 
   <p>
-    By checking this box, you indicate your intent to participate in the Program, and as such:
+    By accepting this declaration, you indicate your intent to participate in the Program as a Registered Contractor. You also:
   </p>
 
   <ul>
+    <li>Agree and accept the Contractor Terms and Conditions and Rebate Eligibility Requirements and acknowledge that the documents impose binding obligations and are enforceable in accordance with the documents' terms</li>
+    <li>Agree that all information provided in relation to the Program will be true and correct and that all products and services provided pursuant to the Program will meet the requirements of the Contractor Terms and Conditions and Rebate Eligibility Requirements</li>
     <li>
-      Agree and accept the Participant Terms and Conditions and Rebate Eligibility Requirements for the relevant Offer(s) and acknowledge that they impose binding obligations and are enforceable in accordance with their terms
+      Understand that the Administrators collect personal information under section 26(c) of the Freedom of Information and Protection of Privacy Act for the purpose of evaluating and improving the Program. If you have any questions about this, please contact <a href="mailto:betterhomesbc@gov.bc.ca">betterhomesbc@gov.bc.ca</a>.
     </li>
-    <li>
-      Certify that all information you provide is accurate and that any products or services installed meet the requirements of the relevant Offer(s)
-    </li>
-    <li>
-      Agree that all information provided in relation to the Program will be true and correct and that all products and services provided pursuant to the Program will meet the requirements of the Participant Terms and Conditions and Rebate Eligibility Requirements
-    </li>
-    <li>
-      Acknowledge that the Program Administrators may collect, use, and disclose your personal information in accordance with applicable laws, the Participant Terms and Conditions, and applicable privacy policies in accordance with the following:
-    </li>
-    <ul>
-      <li>
-        Province of British Columbia - Freedom of Information and Protection of Privacy Act, section 26(c). For more information, contact: Senior Energy Efficiency Coordinator - Residential at <a href="mailto:betterhomesbc@gov.bc.ca">betterhomesbc@gov.bc.ca</a><br>
-        PO Box 9314 Stn Prov Govt, 4th floor, 1810 Blanshard St., Victoria BC V8W 9N1
-      </li>
-    </ul>
   </ul>
 </div>

--- a/eulas/contractor_employee.html
+++ b/eulas/contractor_employee.html
@@ -1,43 +1,28 @@
 <div>
-  <p>
-    <b>Declaration and Consent</b>
-  </p>
+  <p><b>Declaration and consent</b></p>
 
   <p>
-    Participation in the Energy Savings Program (the "Program") requires you to agree to the Participant Terms and Conditions and Rebate Eligibility Requirements. Participation in the Energy Savings Program (the "Program") may involve one or more separate offers (each an "Offer"). Each Offer is governed by its own Participant Terms and Conditions and Rebate Eligibility Requirements.
+    Participation in the CleanBC Better Homes Energy Savings Program (the "Program") requires a contractor to agree to:
   </p>
 
   <ul>
     <li>
-      CleanBC Better Homes Energy Savings Program <a href="https://www.betterhomesbc.ca/esp-participant-terms-ground-oriented-PDF">Participant Terms &amp; Conditions</a> &amp; <a href="https://www.betterhomesbc.ca/esp-requirements-ground-oriented-PDF">Rebate Eligibility Requirements</a>
+      <a href="https://betterhomesbc.ca/esp-contractor-terms-ground-oriented-pdf">Contractor Terms and Conditions</a>
     </li>
     <li>
-      CleanBC Better Homes Energy Savings Program Condo and Apartment Rebate <a href="https://www.betterhomesbc.ca/esp-participant-terms-condo-and-apartment-PDF">Participant Terms &amp; Conditions</a> &amp; <a href="https://www.betterhomesbc.ca/esp-requirements-condo-and-apartment-PDF">Rebate Eligibility Requirements</a>
+      <a href="https://betterhomesbc.ca/learn-about-programs/energy-savings-program/energy-savings-program-requirements/">Rebate Eligibility Requirements</a>
     </li>
   </ul>
 
   <p>
-    By checking this box, you indicate your intent to participate in the Program, and as such:
+    By accepting this declaration, you indicate your intent to participate in the Program as a Registered Contractor. You also:
   </p>
 
   <ul>
+    <li>Agree and accept the Contractor Terms and Conditions and Rebate Eligibility Requirements and acknowledge that the documents impose binding obligations and are enforceable in accordance with the documents' terms</li>
+    <li>Agree that all information provided in relation to the Program will be true and correct and that all products and services provided pursuant to the Program will meet the requirements of the Contractor Terms and Conditions and Rebate Eligibility Requirements</li>
     <li>
-      Agree and accept the Participant Terms and Conditions and Rebate Eligibility Requirements for the relevant Offer(s) and acknowledge that they impose binding obligations and are enforceable in accordance with their terms
+      Understand that the Administrators collect personal information under section 26(c) of the Freedom of Information and Protection of Privacy Act for the purpose of evaluating and improving the Program. If you have any questions about this, please contact <a href="mailto:betterhomesbc@gov.bc.ca">betterhomesbc@gov.bc.ca</a>.
     </li>
-    <li>
-      Certify that all information you provide is accurate and that any products or services installed meet the requirements of the relevant Offer(s)
-    </li>
-    <li>
-      Agree that all information provided in relation to the Program will be true and correct and that all products and services provided pursuant to the Program will meet the requirements of the Participant Terms and Conditions and Rebate Eligibility Requirements
-    </li>
-    <li>
-      Acknowledge that the Program Administrators may collect, use, and disclose your personal information in accordance with applicable laws, the Participant Terms and Conditions, and applicable privacy policies in accordance with the following:
-    </li>
-    <ul>
-      <li>
-        Province of British Columbia - Freedom of Information and Protection of Privacy Act, section 26(c). For more information, contact: Senior Energy Efficiency Coordinator - Residential at <a href="mailto:betterhomesbc@gov.bc.ca">betterhomesbc@gov.bc.ca</a><br>
-        PO Box 9314 Stn Prov Govt, 4th floor, 1810 Blanshard St., Victoria BC V8W 9N1
-      </li>
-    </ul>
   </ul>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "react-leaflet": "^4.2.1",
         "react-markdown": "^9.0.1",
         "react-password-strength-bar": "^0.4.1",
-        "react-quill": "^2.0.0",
         "react-remove-scroll": "^2.5.7",
         "react-router-dom": "^6.20.0",
         "react-select": "^5.10.1",
@@ -17333,6 +17332,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
       "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/parent-module": {
@@ -18357,30 +18357,6 @@
       "peerDependencies": {
         "react": ">=16.8.6",
         "react-dom": ">=16.8.6"
-      }
-    },
-    "node_modules/react-quill": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
-      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/quill": "^1.3.10",
-        "lodash": "^4.17.4",
-        "quill": "^1.3.7"
-      },
-      "peerDependencies": {
-        "react": "^16 || ^17 || ^18",
-        "react-dom": "^16 || ^17 || ^18"
-      }
-    },
-    "node_modules/react-quill/node_modules/@types/quill": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
-      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
-      "license": "MIT",
-      "dependencies": {
-        "parchment": "^1.1.2"
       }
     },
     "node_modules/react-remove-scroll": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "react-leaflet": "^4.2.1",
     "react-markdown": "^9.0.1",
     "react-password-strength-bar": "^0.4.1",
-    "react-quill": "^2.0.0",
     "react-remove-scroll": "^2.5.7",
     "react-router-dom": "^6.20.0",
     "react-select": "^5.10.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,6 @@ export default defineConfig({
   optimizeDeps: {
     // Force esbuild to pre-bundle CJS packages into ESM so rolldown
     // doesn't mangle their default exports (React error #130)
-    include: ['react-quill', 'formiojs', '@formio/react', '@formio/js'],
+    include: ['formiojs', '@formio/react', '@formio/js'],
   },
 });


### PR DESCRIPTION
…nd fix quill bullet rendering but updating quill.css

quill.css was importing react-quill's CDN-published CSS bundle (stale, built against quill@^1.3.7) instead of the actual quill@2.0.2 package this app runs. Removed react-quill entirely since nothing in the app depends on it anymore.