### PR TITLE
fix(BCHEP-575): fix some issues with the new revision request limit

### DIFF
--- a/app/models/revision_request.rb
+++ b/app/models/revision_request.rb
@@ -8,6 +8,7 @@ class RevisionRequest < ApplicationRecord
              primary_key: :reason_code,
              optional: true
 
+  validates :comment, length: { maximum: 1000 }
   validate :user_must_be_review_staff
 
   private

--- a/db/migrate/20260710213000_increase_revision_request_comment_limit.rb
+++ b/db/migrate/20260710213000_increase_revision_request_comment_limit.rb
@@ -4,7 +4,11 @@ class IncreaseRevisionRequestCommentLimit < ActiveRecord::Migration[7.1]
   end
 
   def down
-    if RevisionRequest.where("length(comment) > 350").exists?
+    oversized =
+      select_value(
+        "SELECT 1 FROM revision_requests WHERE length(comment) > 350 LIMIT 1"
+      )
+    if oversized
       raise ActiveRecord::IrreversibleMigration,
             "Cannot revert to limit: 350 while comments longer than 350 characters exist"
     end

--- a/spec/models/revision_request_spec.rb
+++ b/spec/models/revision_request_spec.rb
@@ -3,8 +3,25 @@ require "rails_helper"
 
 RSpec.describe RevisionRequest, type: :model do
   describe "comment column" do
-    it "allows comments up to the configured limit" do
+    it "has a DB column limit of 1000 characters" do
       expect(RevisionRequest.columns_hash["comment"].limit).to eq(1000)
+    end
+  end
+
+  describe "comment validation" do
+    let(:revision_request) do
+      build(:revision_request, user: build(:user, role: :admin))
+    end
+
+    it "is valid at exactly 1000 characters" do
+      revision_request.comment = "a" * 1000
+      expect(revision_request).to be_valid
+    end
+
+    it "is invalid over 1000 characters, without raising a DB error" do
+      revision_request.comment = "a" * 1001
+      expect(revision_request).not_to be_valid
+      expect(revision_request.errors[:comment]).to be_present
     end
   end
 end


### PR DESCRIPTION
- Migration no longer references the RevisionRequest model constant; the rollback guard now uses a raw SQL check instead, so it can't break from unrelated future model changes.
- Added a model-level length validation matching the DB limit, so a client bypassing the UI cap fails with a normal validation error instead of a raw Postgres exception.
- Clarified spec wording and added coverage for the new validation.