### PR TITLE
feat(BCHEP-729): track contractor suspend/unsuspend/remove history

### DIFF
--- a/app/blueprints/contractor_status_event_blueprint.rb
+++ b/app/blueprints/contractor_status_event_blueprint.rb
@@ -1,0 +1,9 @@
+class ContractorStatusEventBlueprint < Blueprinter::Base
+  view :base do
+    identifier :id
+
+    fields :event_type, :reason, :created_at
+
+    association :performed_by, blueprint: UserBlueprint, view: :minimal
+  end
+end

--- a/app/controllers/api/contractors_controller.rb
+++ b/app/controllers/api/contractors_controller.rb
@@ -10,6 +10,7 @@ class Api::ContractorsController < Api::ApplicationController
                   suspend
                   unsuspend
                   deactivate
+                  status_history
                 ]
   skip_before_action :authenticate_user!, only: %i[shim]
   skip_after_action :verify_authorized, only: %i[shim by_user]
@@ -129,34 +130,42 @@ class Api::ContractorsController < Api::ApplicationController
       )
     end
 
-    # Suspend the contractor (sets suspended_at on contractor_onboard)
-    if onboard.update(
-         suspended_at: Time.current,
-         suspended_reason: params[:reason],
-         suspended_by: current_user
-       )
-      # Send email notification to primary contact
-      # TODO: Re-enable if client wants emails sent
-      # PermitHubMailer.contractor_suspended(@contractor).deliver_later
-
-      # Reindex for Elasticsearch
-      @contractor.reindex
-
-      # Return success
-      render_success @contractor,
-                     "contractor.suspended",
-                     {
-                       blueprint: ContractorBlueprint,
-                       blueprint_opts: {
-                         view: :base
-                       }
-                     }
-    else
-      render json: {
-               error: onboard.errors.full_messages
-             },
-             status: :unprocessable_entity
+    # Suspend the contractor (sets suspended_at on contractor_onboard) and
+    # record a permanent history event in the same transaction.
+    begin
+      ActiveRecord::Base.transaction do
+        onboard.update!(
+          suspended_at: Time.current,
+          suspended_reason: params[:reason],
+          suspended_by: current_user
+        )
+        record_status_event!(onboard, "suspend", params[:reason])
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      return(
+        render json: {
+                 error: e.record.errors.full_messages
+               },
+               status: :unprocessable_entity
+      )
     end
+
+    # Send email notification to primary contact
+    # TODO: Re-enable if client wants emails sent
+    # PermitHubMailer.contractor_suspended(@contractor).deliver_later
+
+    # Reindex for Elasticsearch
+    @contractor.reindex
+
+    # Return success
+    render_success @contractor,
+                   "contractor.suspended",
+                   {
+                     blueprint: ContractorBlueprint,
+                     blueprint_opts: {
+                       view: :base
+                     }
+                   }
   end
 
   def unsuspend
@@ -176,33 +185,42 @@ class Api::ContractorsController < Api::ApplicationController
       )
     end
 
-    # Unsuspend the contractor (clears suspended_at, suspended_reason, and suspended_by on contractor_onboard)
-    if onboard.update(
-         suspended_at: nil,
-         suspended_reason: nil,
-         suspended_by: nil
-       )
-      # Send email notification to primary contact
-      # TODO: Re-enable if client wants emails sent
-      # PermitHubMailer.contractor_unsuspended(@contractor).deliver_later
-
-      # Reindex for Elasticsearch
-      @contractor.reindex
-
-      render_success @contractor,
-                     "contractor.unsuspended",
-                     {
-                       blueprint: ContractorBlueprint,
-                       blueprint_opts: {
-                         view: :base
-                       }
-                     }
-    else
-      render json: {
-               error: onboard.errors.full_messages
-             },
-             status: :unprocessable_entity
+    # Unsuspend the contractor (clears suspended_at, suspended_reason, and
+    # suspended_by on contractor_onboard) and record a permanent history event
+    # in the same transaction. No reason is collected on unsuspend.
+    begin
+      ActiveRecord::Base.transaction do
+        onboard.update!(
+          suspended_at: nil,
+          suspended_reason: nil,
+          suspended_by: nil
+        )
+        record_status_event!(onboard, "unsuspend", nil)
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      return(
+        render json: {
+                 error: e.record.errors.full_messages
+               },
+               status: :unprocessable_entity
+      )
     end
+
+    # Send email notification to primary contact
+    # TODO: Re-enable if client wants emails sent
+    # PermitHubMailer.contractor_unsuspended(@contractor).deliver_later
+
+    # Reindex for Elasticsearch
+    @contractor.reindex
+
+    render_success @contractor,
+                   "contractor.unsuspended",
+                   {
+                     blueprint: ContractorBlueprint,
+                     blueprint_opts: {
+                       view: :base
+                     }
+                   }
   end
 
   def deactivate
@@ -222,33 +240,62 @@ class Api::ContractorsController < Api::ApplicationController
       )
     end
 
-    # Deactivate the contractor (sets deactivated_at, deactivated_reason, and deactivated_by on contractor_onboard)
-    if onboard.update(
-         deactivated_at: Time.current,
-         deactivated_reason: params[:reason],
-         deactivated_by: current_user
-       )
-      # Send email notification to primary contact
-      # TODO: Re-enable if client wants emails sent
-      # PermitHubMailer.contractor_removed(@contractor).deliver_later
-
-      # Reindex for Elasticsearch
-      @contractor.reindex
-
-      render_success @contractor,
-                     "contractor.removed",
-                     {
-                       blueprint: ContractorBlueprint,
-                       blueprint_opts: {
-                         view: :base
-                       }
-                     }
-    else
-      render json: {
-               error: onboard.errors.full_messages
-             },
-             status: :unprocessable_entity
+    # Deactivate the contractor (sets deactivated_at, deactivated_reason, and
+    # deactivated_by on contractor_onboard) and record a permanent history
+    # event in the same transaction. The event_type is "remove" to match the
+    # frontend's wording for this action.
+    begin
+      ActiveRecord::Base.transaction do
+        onboard.update!(
+          deactivated_at: Time.current,
+          deactivated_reason: params[:reason],
+          deactivated_by: current_user
+        )
+        record_status_event!(onboard, "remove", params[:reason])
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      return(
+        render json: {
+                 error: e.record.errors.full_messages
+               },
+               status: :unprocessable_entity
+      )
     end
+
+    # Send email notification to primary contact
+    # TODO: Re-enable if client wants emails sent
+    # PermitHubMailer.contractor_removed(@contractor).deliver_later
+
+    # Reindex for Elasticsearch
+    @contractor.reindex
+
+    render_success @contractor,
+                   "contractor.removed",
+                   {
+                     blueprint: ContractorBlueprint,
+                     blueprint_opts: {
+                       view: :base
+                     }
+                   }
+  end
+
+  def status_history
+    authorize @contractor, :status_history?
+
+    events =
+      @contractor
+        .contractor_status_events
+        .includes(:performed_by)
+        .order(created_at: :desc)
+
+    render_success events,
+                   nil,
+                   {
+                     blueprint: ContractorStatusEventBlueprint,
+                     blueprint_opts: {
+                       view: :base
+                     }
+                   }
   end
 
   def by_user
@@ -275,6 +322,15 @@ class Api::ContractorsController < Api::ApplicationController
 
   def set_contractor
     @contractor = Contractor.find(params[:id])
+  end
+
+  def record_status_event!(onboard, event_type, reason)
+    @contractor.contractor_status_events.create!(
+      contractor_onboard: onboard,
+      event_type: event_type,
+      reason: reason,
+      performed_by: current_user
+    )
   end
 
   def contractor_params

--- a/app/frontend/components/domains/contractor-management/contractor-table-rows.tsx
+++ b/app/frontend/components/domains/contractor-management/contractor-table-rows.tsx
@@ -1,22 +1,23 @@
-import { Badge, Box, Flex, Menu, MenuButton, MenuItem, MenuList, Link } from '@chakra-ui/react';
+import { Box, Flex, Link, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
 import {
-  Eye,
-  PencilSimple,
-  Envelope,
-  Users,
-  Prohibit,
-  HourglassMedium,
-  Trash,
   ArrowsLeftRight,
+  ClockCounterClockwise,
+  Envelope,
+  Eye,
+  HourglassMedium,
+  PencilSimple,
+  Trash,
+  Users,
 } from '@phosphor-icons/react';
 import { observer } from 'mobx-react-lite';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { IContractor } from '../../../models/contractor';
-import { SearchGridItem } from '../../shared/grid/search-grid-item';
 import { useMst } from '../../../setup/root';
+import { SearchGridItem } from '../../shared/grid/search-grid-item';
 import { GlobalConfirmationModal } from '../../shared/modals/global-confirmation-modal';
+import { StatusHistoryModal } from './status-history-modal';
 
 interface ContractorRowProps {
   contractor: IContractor;
@@ -30,6 +31,7 @@ export const ContractorRow = observer(({ contractor, status = 'active' }: Contra
   const [isSuspendModalOpen, setIsSuspendModalOpen] = useState(false);
   const [isUnsuspendModalOpen, setIsUnsuspendModalOpen] = useState(false);
   const [isRemoveModalOpen, setIsRemoveModalOpen] = useState(false);
+  const [isHistoryModalOpen, setIsHistoryModalOpen] = useState(false);
 
   const handleEdit = () => {
     contractorStore.fetchOnboarding(contractor.id).then((onboarding) => {
@@ -88,6 +90,10 @@ export const ContractorRow = observer(({ contractor, status = 'active' }: Contra
 
   const handleRemove = () => {
     setIsRemoveModalOpen(true);
+  };
+
+  const handleViewHistory = () => {
+    setIsHistoryModalOpen(true);
   };
 
   const handleRemoveConfirm = () => {
@@ -291,6 +297,21 @@ export const ContractorRow = observer(({ contractor, status = 'active' }: Contra
                     {t('contractor.actions.suspendContractor')}
                   </MenuItem>
                   <MenuItem
+                    icon={<ClockCounterClockwise />}
+                    onClick={handleViewHistory}
+                    role="menuitem"
+                    aria-label={`View status history for ${contractor.businessName}`}
+                    _focus={{ bg: 'blue.50', outline: 'none' }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleViewHistory();
+                      }
+                    }}
+                  >
+                    {t('contractor.actions.viewStatusHistory')}
+                  </MenuItem>
+                  <MenuItem
                     icon={<Trash />}
                     onClick={handleRemove}
                     color="red.500"
@@ -343,6 +364,21 @@ export const ContractorRow = observer(({ contractor, status = 'active' }: Contra
                     {t('contractor.actions.viewContractor')}
                   </MenuItem>
                   <MenuItem
+                    icon={<ClockCounterClockwise />}
+                    onClick={handleViewHistory}
+                    role="menuitem"
+                    aria-label={`View status history for ${contractor.businessName}`}
+                    _focus={{ bg: 'blue.50', outline: 'none' }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleViewHistory();
+                      }
+                    }}
+                  >
+                    {t('contractor.actions.viewStatusHistory')}
+                  </MenuItem>
+                  <MenuItem
                     icon={<Trash />}
                     onClick={handleRemove}
                     color="red.500"
@@ -361,23 +397,40 @@ export const ContractorRow = observer(({ contractor, status = 'active' }: Contra
                 </>
               )}
 
-              {/* Removed contractors: View contractor only */}
+              {/* Removed contractors: View contractor, View history */}
               {contractor.isDeactivated && (
-                <MenuItem
-                  icon={<Eye />}
-                  onClick={handleView}
-                  role="menuitem"
-                  aria-label={`View contractor ${contractor.businessName}`}
-                  _focus={{ bg: 'blue.50', outline: 'none' }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      handleView();
-                    }
-                  }}
-                >
-                  {t('contractor.actions.viewContractor')}
-                </MenuItem>
+                <>
+                  <MenuItem
+                    icon={<Eye />}
+                    onClick={handleView}
+                    role="menuitem"
+                    aria-label={`View contractor ${contractor.businessName}`}
+                    _focus={{ bg: 'blue.50', outline: 'none' }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleView();
+                      }
+                    }}
+                  >
+                    {t('contractor.actions.viewContractor')}
+                  </MenuItem>
+                  <MenuItem
+                    icon={<ClockCounterClockwise />}
+                    onClick={handleViewHistory}
+                    role="menuitem"
+                    aria-label={`View status history for ${contractor.businessName}`}
+                    _focus={{ bg: 'blue.50', outline: 'none' }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleViewHistory();
+                      }
+                    }}
+                  >
+                    {t('contractor.actions.viewStatusHistory')}
+                  </MenuItem>
+                </>
               )}
             </MenuList>
           </Menu>
@@ -438,6 +491,12 @@ export const ContractorRow = observer(({ contractor, status = 'active' }: Contra
         onSubmit={handleRemoveConfirm}
         confirmText={t('ui.confirm', 'Confirm')}
         cancelText={t('ui.cancel', 'Cancel')}
+      />
+
+      <StatusHistoryModal
+        contractor={contractor}
+        isOpen={isHistoryModalOpen}
+        onClose={() => setIsHistoryModalOpen(false)}
       />
     </Box>
   );

--- a/app/frontend/components/domains/contractor-management/status-history-modal.tsx
+++ b/app/frontend/components/domains/contractor-management/status-history-modal.tsx
@@ -47,15 +47,20 @@ export const StatusHistoryModal = observer(({ contractor, isOpen, onClose }: ISt
   const { contractorStore } = useMst();
   const [events, setEvents] = useState<IContractorStatusEvent[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [hasError, setHasError] = useState(false);
 
   useEffect(() => {
     if (!isOpen) return;
     let active = true;
     setIsLoading(true);
+    setHasError(false);
     contractorStore
       .fetchStatusHistory(contractor.id)
       .then((result: IContractorStatusEvent[]) => {
         if (active) setEvents(result ?? []);
+      })
+      .catch(() => {
+        if (active) setHasError(true);
       })
       .finally(() => {
         if (active) setIsLoading(false);
@@ -86,6 +91,8 @@ export const StatusHistoryModal = observer(({ contractor, isOpen, onClose }: ISt
             <Flex justify="center" py={8}>
               <Spinner aria-label={t('contractor.statusHistory.loading')} />
             </Flex>
+          ) : hasError ? (
+            <Text color="semantic.error">{t('contractor.statusHistory.error')}</Text>
           ) : events.length === 0 ? (
             <Text color="text.secondary">{t('contractor.statusHistory.empty')}</Text>
           ) : (

--- a/app/frontend/components/domains/contractor-management/status-history-modal.tsx
+++ b/app/frontend/components/domains/contractor-management/status-history-modal.tsx
@@ -95,7 +95,7 @@ export const StatusHistoryModal = observer(({ contractor, isOpen, onClose }: ISt
               aria-label={t('contractor.statusHistory.listLabel')}
               align="stretch"
               spacing={3}
-              divider={<Divider />}
+              divider={<Divider as="li" aria-hidden="true" />}
               listStyleType="none"
               m={0}
               p={0}

--- a/app/frontend/components/domains/contractor-management/status-history-modal.tsx
+++ b/app/frontend/components/domains/contractor-management/status-history-modal.tsx
@@ -1,0 +1,161 @@
+import {
+  Box,
+  Button,
+  Divider,
+  Flex,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Spinner,
+  Tag,
+  TagLabel,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
+import { format } from 'date-fns';
+import { observer } from 'mobx-react-lite';
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { IContractor } from '../../../models/contractor';
+import { useMst } from '../../../setup/root';
+import { IContractorStatusEvent, TContractorStatusEventType } from '../../../types/types';
+
+interface IStatusHistoryModalProps {
+  contractor: IContractor;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+// Uses the design system's semantic tokens (see styles/theme/foundations/
+// colors.ts) rather than raw Chakra colorSchemes, matching the app's other
+// status tags (e.g. preview-status-tag.tsx).
+const EVENT_TAG_COLORS: Record<TContractorStatusEventType, { bg: string; border: string }> = {
+  suspend: { bg: 'semantic.warningLight', border: 'semantic.warning' },
+  unsuspend: { bg: 'semantic.successLight', border: 'semantic.success' },
+  remove: { bg: 'semantic.errorLight', border: 'semantic.error' },
+};
+
+// Read-only modal listing the permanent suspend/unsuspend/remove history for a
+// contractor (backed by contractor_status_events). Fetches fresh each time it
+// opens; the events are not held in the store.
+export const StatusHistoryModal = observer(({ contractor, isOpen, onClose }: IStatusHistoryModalProps) => {
+  const { t } = useTranslation();
+  const { contractorStore } = useMst();
+  const [events, setEvents] = useState<IContractorStatusEvent[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let active = true;
+    setIsLoading(true);
+    contractorStore
+      .fetchStatusHistory(contractor.id)
+      .then((result: IContractorStatusEvent[]) => {
+        if (active) setEvents(result ?? []);
+      })
+      .finally(() => {
+        if (active) setIsLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [isOpen, contractor.id]);
+
+  const actorName = (event: IContractorStatusEvent) => {
+    const user = event.performedBy;
+    const name = `${user?.firstName ?? ''} ${user?.lastName ?? ''}`.trim();
+    return name || user?.email || t('contractor.statusHistory.unknownActor');
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="lg" scrollBehavior="inside">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>{t('contractor.statusHistory.title')}</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Text fontSize="sm" color="text.secondary" mb={4}>
+            {t('contractor.statusHistory.subtitle', { name: contractor.businessName })}
+          </Text>
+
+          {isLoading ? (
+            <Flex justify="center" py={8}>
+              <Spinner aria-label={t('contractor.statusHistory.loading')} />
+            </Flex>
+          ) : events.length === 0 ? (
+            <Text color="text.secondary">{t('contractor.statusHistory.empty')}</Text>
+          ) : (
+            <VStack
+              as="ul"
+              role="list"
+              aria-label={t('contractor.statusHistory.listLabel')}
+              align="stretch"
+              spacing={3}
+              divider={<Divider />}
+              listStyleType="none"
+              m={0}
+              p={0}
+            >
+              {events.map((event) => {
+                const eventLabel = t(`contractor.statusHistory.eventType.${event.eventType}`);
+                const actor = actorName(event);
+                const date = event.createdAt ? format(new Date(event.createdAt), 'yyyy-MM-dd HH:mm') : '';
+                // Group the tag/actor/date/reason fragments into one phrase so a
+                // screen reader announces each entry as a single coherent item.
+                const entryAria = event.reason
+                  ? t('contractor.statusHistory.entryAriaWithReason', {
+                      event: eventLabel,
+                      actor,
+                      date,
+                      reason: event.reason,
+                    })
+                  : t('contractor.statusHistory.entryAria', { event: eventLabel, actor, date });
+                return (
+                  <Box key={event.id} as="li" role="listitem" aria-label={entryAria}>
+                    {/* Visual detail is aria-hidden - the entry's aria-label above
+                        already conveys it as one phrase, avoiding double reading. */}
+                    <Flex align="center" gap={2} mb={1} wrap="wrap" aria-hidden="true">
+                      <Tag
+                        size="sm"
+                        borderRadius="0"
+                        variant="solid"
+                        bg={EVENT_TAG_COLORS[event.eventType].bg}
+                        border="1px solid"
+                        borderColor={EVENT_TAG_COLORS[event.eventType].border}
+                        color="text.primary"
+                        textTransform="uppercase"
+                      >
+                        <TagLabel fontWeight="bold">
+                          {t(`contractor.statusHistory.eventType.${event.eventType}`)}
+                        </TagLabel>
+                      </Tag>
+                      <Text fontSize="sm" color="text.secondary" mb={0}>
+                        {actorName(event)}
+                        {event.createdAt ? ` · ${format(new Date(event.createdAt), 'yyyy-MM-dd HH:mm')}` : ''}
+                      </Text>
+                    </Flex>
+                    {event.reason ? (
+                      <Text fontSize="sm" whiteSpace="pre-wrap" mb={0} aria-hidden="true">
+                        <Text as="span" fontWeight="bold">
+                          {t('contractor.statusHistory.reasonLabel')}:{' '}
+                        </Text>
+                        {event.reason}
+                      </Text>
+                    ) : null}
+                  </Box>
+                );
+              })}
+            </VStack>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={onClose}>{t('contractor.statusHistory.close')}</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+});

--- a/app/frontend/components/domains/energy-savings-application/internal-comments-panel.tsx
+++ b/app/frontend/components/domains/energy-savings-application/internal-comments-panel.tsx
@@ -60,7 +60,7 @@ export const InternalCommentsPanel = observer(({ permitApplication }: IInternalC
             aria-label={t('energySavingsApplication.show.internalComments.title')}
             align="stretch"
             spacing={3}
-            divider={<Divider />}
+            divider={<Divider as="li" aria-hidden="true" />}
             listStyleType="none"
             m={0}
             p={0}

--- a/app/frontend/components/domains/energy-savings-application/internal-comments-panel.tsx
+++ b/app/frontend/components/domains/energy-savings-application/internal-comments-panel.tsx
@@ -54,9 +54,19 @@ export const InternalCommentsPanel = observer(({ permitApplication }: IInternalC
 
       <Collapse in={isOpen} animateOpacity>
         <Box id={`internal-comments-${permitApplication.id}`} bg="greys.grey03" px={4} pb={4}>
-          <VStack align="stretch" spacing={3} divider={<Divider />}>
+          <VStack
+            as="ul"
+            role="list"
+            aria-label={t('energySavingsApplication.show.internalComments.title')}
+            align="stretch"
+            spacing={3}
+            divider={<Divider />}
+            listStyleType="none"
+            m={0}
+            p={0}
+          >
             {comments.map((comment) => (
-              <Box key={comment.id}>
+              <Box as="li" role="listitem" key={comment.id}>
                 <Text fontSize="sm" color="text.secondary">
                   {`${comment.user?.firstName ?? ''} ${comment.user?.lastName ?? ''}`.trim() ||
                     t('energySavingsApplication.show.internalComments.unknownAuthor')}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -3300,6 +3300,7 @@ const options = {
             subtitle: 'Suspend, unsuspend, and removal history for {{name}}.',
             loading: 'Loading history...',
             empty: 'No status history yet.',
+            error: 'Could not load status history. Please try again.',
             reasonLabel: 'Reason',
             unknownActor: 'Unknown',
             close: 'Close',

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -3293,6 +3293,24 @@ const options = {
             suspendContractor: 'Suspend contractor',
             unsuspendContractor: 'Unsuspend contractor',
             removeContractor: 'Remove contractor',
+            viewStatusHistory: 'View status history',
+          },
+          statusHistory: {
+            title: 'Status history',
+            subtitle: 'Suspend, unsuspend, and removal history for {{name}}.',
+            loading: 'Loading history...',
+            empty: 'No status history yet.',
+            reasonLabel: 'Reason',
+            unknownActor: 'Unknown',
+            close: 'Close',
+            listLabel: 'Status change history',
+            entryAria: '{{event}} by {{actor}} on {{date}}',
+            entryAriaWithReason: '{{event}} by {{actor}} on {{date}}. Reason: {{reason}}',
+            eventType: {
+              suspend: 'Suspended',
+              unsuspend: 'Unsuspended',
+              remove: 'Removed',
+            },
           },
           suspend: {
             modal: {

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -452,6 +452,10 @@ export class Api {
     });
   }
 
+  async getContractorStatusHistory(contractorId: string) {
+    return this.client.get<ApiResponse<any>>(`/contractors/${contractorId}/status_history`);
+  }
+
   async createContractorOnboarding(contractorId: string) {
     return this.client.post<ApiResponse<any>>(`/contractor_onboards`, {
       contractor_id: contractorId,

--- a/app/frontend/stores/contractor-store.ts
+++ b/app/frontend/stores/contractor-store.ts
@@ -4,8 +4,8 @@ import { createSearchModel } from '../lib/create-search-model';
 import { withEnvironment } from '../lib/with-environment';
 import { withMerge } from '../lib/with-merge';
 import { withRootStore } from '../lib/with-root-store';
-import { IContractor, ContractorModel } from '../models/contractor';
-import { ContractorOnboardModel } from '../models/contractor-onboard';
+import { ContractorModel, IContractor } from '../models/contractor';
+import { IContractorStatusEvent } from '../types/types';
 
 export enum EContractorSortFields {
   id = 'number',
@@ -267,6 +267,13 @@ export const ContractorStoreModel = types
       }
 
       return response;
+    }),
+    fetchStatusHistory: flow(function* (contractorId: string) {
+      const response = yield self.environment.api.getContractorStatusHistory(contractorId);
+      if (response.ok) {
+        return (response.data.data as IContractorStatusEvent[]) ?? [];
+      }
+      return [] as IContractorStatusEvent[];
     }),
     validateImportToken: flow(function* (token: string) {
       const response = yield self.environment.api.validateContractorImportToken(token);

--- a/app/frontend/stores/contractor-store.ts
+++ b/app/frontend/stores/contractor-store.ts
@@ -270,10 +270,12 @@ export const ContractorStoreModel = types
     }),
     fetchStatusHistory: flow(function* (contractorId: string) {
       const response = yield self.environment.api.getContractorStatusHistory(contractorId);
-      if (response.ok) {
-        return (response.data.data as IContractorStatusEvent[]) ?? [];
+      // Throw (rather than return []) so the modal can tell "no events" apart
+      // from a failed/forbidden request and show an error instead of empty.
+      if (!response.ok) {
+        throw new Error('Failed to load contractor status history');
       }
-      return [] as IContractorStatusEvent[];
+      return (response.data.data as IContractorStatusEvent[]) ?? [];
     }),
     validateImportToken: flow(function* (token: string) {
       const response = yield self.environment.api.validateContractorImportToken(token);

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -557,7 +557,7 @@ export interface IContractorStatusEvent {
   id: string;
   eventType: TContractorStatusEventType;
   reason?: string | null;
-  createdAt: string;
+  createdAt: number;
   performedBy?: IMinimalFrozenUser;
 }
 

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -551,6 +551,16 @@ export interface IInternalComment {
   user?: IMinimalFrozenUser;
 }
 
+export type TContractorStatusEventType = 'suspend' | 'unsuspend' | 'remove';
+
+export interface IContractorStatusEvent {
+  id: string;
+  eventType: TContractorStatusEventType;
+  reason?: string | null;
+  createdAt: string;
+  performedBy?: IMinimalFrozenUser;
+}
+
 export interface ISubmissionVersion {
   id: string;
   formJson: IFormJson;

--- a/app/models/contractor.rb
+++ b/app/models/contractor.rb
@@ -24,6 +24,7 @@ class Contractor < ApplicationRecord
   belongs_to :contact, class_name: "User", optional: true
 
   has_many :contractor_onboards, dependent: :destroy
+  has_many :contractor_status_events, dependent: :destroy
   has_many :contractor_employees, dependent: :destroy
   has_many :employees, through: :contractor_employees, source: :employee
   has_many :permit_applications, as: :submitter

--- a/app/models/contractor_status_event.rb
+++ b/app/models/contractor_status_event.rb
@@ -1,0 +1,16 @@
+class ContractorStatusEvent < ApplicationRecord
+  # "remove" (not "deactivate") mirrors the frontend's wording for the
+  # deactivate action (handleRemove / contractor.removed).
+  EVENT_TYPES = %w[suspend unsuspend remove].freeze
+
+  belongs_to :contractor
+  belongs_to :contractor_onboard
+  belongs_to :performed_by, class_name: "User", optional: true
+
+  # This is a faithful recorder of what happened - it never gates a status
+  # change. "reason required" is enforced where the rule lives: the frontend
+  # suspend/remove reason pages. (A blank reason here would mean something
+  # genuinely got suspended without one - we'd want to record that, not reject
+  # it.)
+  validates :event_type, presence: true, inclusion: { in: EVENT_TYPES }
+end

--- a/app/policies/contractor_policy.rb
+++ b/app/policies/contractor_policy.rb
@@ -44,6 +44,13 @@ class ContractorPolicy < ApplicationPolicy
     user.admin? || user.admin_manager?
   end
 
+  def status_history?
+    # Anyone who can suspend can view the suspend/unsuspend/remove history.
+    # (Deliberately broader than AuditLogPolicy, which is admin_manager/
+    # system_admin only - a plain admin can suspend, so must see the history.)
+    user.admin? || user.admin_manager?
+  end
+
   def deactivate?
     # Admin managers and admins can deactivate contractors
     user.admin_manager? || user.admin?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -279,6 +279,9 @@ Rails.application.routes.draw do
       # Deactivate (remove) contractor
       post "deactivate", on: :member, to: "contractors#deactivate"
 
+      # Suspend/unsuspend/remove history
+      get "status_history", on: :member, to: "contractors#status_history"
+
       resources :employees, controller: "contractor_employees", only: [] do
         collection { post :invite }
         member do

--- a/db/migrate/20260720120000_create_contractor_status_events.rb
+++ b/db/migrate/20260720120000_create_contractor_status_events.rb
@@ -1,0 +1,28 @@
+class CreateContractorStatusEvents < ActiveRecord::Migration[8.1]
+  def change
+    create_table :contractor_status_events, id: :uuid do |t|
+      t.references :contractor,
+                   null: false,
+                   foreign_key: true,
+                   type: :uuid,
+                   index: false
+      t.references :contractor_onboard,
+                   null: false,
+                   foreign_key: true,
+                   type: :uuid
+      t.references :performed_by,
+                   null: true,
+                   foreign_key: {
+                     to_table: :users
+                   },
+                   type: :uuid
+      t.string :event_type, null: false
+      t.text :reason
+
+      t.timestamps
+    end
+
+    # History is always queried per-contractor, newest first.
+    add_index :contractor_status_events, %i[contractor_id created_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_15_194414) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_20_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -218,6 +218,26 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_15_194414) do
             name: "index_contractor_onboards_on_contractor_id"
     t.index ["onboard_application_id"],
             name: "index_contractor_onboards_on_onboard_application_id"
+  end
+
+  create_table "contractor_status_events",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
+    t.uuid "contractor_id", null: false
+    t.uuid "contractor_onboard_id", null: false
+    t.datetime "created_at", null: false
+    t.string "event_type", null: false
+    t.uuid "performed_by_id"
+    t.text "reason"
+    t.datetime "updated_at", null: false
+    t.index %w[contractor_id created_at],
+            name:
+              "index_contractor_status_events_on_contractor_id_and_created_at"
+    t.index ["contractor_onboard_id"],
+            name: "index_contractor_status_events_on_contractor_onboard_id"
+    t.index ["performed_by_id"],
+            name: "index_contractor_status_events_on_performed_by_id"
   end
 
   create_table "contractors",
@@ -1245,6 +1265,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_15_194414) do
                   column: "onboard_application_id"
   add_foreign_key "contractor_onboards", "users", column: "deactivated_by"
   add_foreign_key "contractor_onboards", "users", column: "suspended_by"
+  add_foreign_key "contractor_status_events", "contractor_onboards"
+  add_foreign_key "contractor_status_events", "contractors"
+  add_foreign_key "contractor_status_events", "users", column: "performed_by_id"
   add_foreign_key "contractors", "users", column: "contact_id"
   add_foreign_key "early_access_previews", "users", column: "previewer_id"
   add_foreign_key "external_api_keys", "jurisdictions"

--- a/spec/controllers/contractors_controller_spec.rb
+++ b/spec/controllers/contractors_controller_spec.rb
@@ -1,0 +1,166 @@
+require "rails_helper"
+
+RSpec.describe Api::ContractorsController, type: :controller do
+  let(:admin_user) do
+    User.create!(
+      first_name: "Admin",
+      last_name: "User",
+      email: "csc-admin@example.com",
+      password: "P@ssword1",
+      role: :admin,
+      confirmed_at: Time.current
+    )
+  end
+
+  let(:admin_manager_user) do
+    User.create!(
+      first_name: "Manager",
+      last_name: "User",
+      email: "csc-mgr@example.com",
+      password: "P@ssword1",
+      role: :admin_manager,
+      confirmed_at: Time.current
+    )
+  end
+
+  let(:participant_user) do
+    User.create!(
+      first_name: "Part",
+      last_name: "User",
+      email: "csc-part@example.com",
+      password: "P@ssword1",
+      role: :participant,
+      confirmed_at: Time.current
+    )
+  end
+
+  let(:contractor) do
+    Contractor.create!(
+      business_name: "Controller Spec Contractor",
+      contact: admin_user
+    )
+  end
+
+  let(:onboard_application) do
+    create(:permit_application, submitter: contractor)
+  end
+
+  let!(:onboard) do
+    ContractorOnboard.create!(
+      contractor: contractor,
+      onboard_application: onboard_application
+    )
+  end
+
+  def json_response
+    JSON.parse(response.body)
+  end
+
+  before do
+    # Keep the specs off Elasticsearch - the actions call @contractor.reindex.
+    allow_any_instance_of(Contractor).to receive(:reindex)
+    sign_in admin_user
+  end
+
+  describe "POST #suspend" do
+    it "suspends and records a suspend event with reason + actor" do
+      post :suspend, params: { id: contractor.id, reason: "late invoices" }
+
+      expect(response).to have_http_status(:success)
+      event = contractor.contractor_status_events.order(:created_at).last
+      expect(event.event_type).to eq("suspend")
+      expect(event.reason).to eq("late invoices")
+      expect(event.performed_by_id).to eq(admin_user.id)
+      expect(event.contractor_onboard_id).to eq(onboard.id)
+      expect(onboard.reload.suspended_at).to be_present
+    end
+
+    it "rolls back the suspend if the event write fails (atomic)" do
+      allow_any_instance_of(ContractorStatusEvent).to receive(
+        :valid?
+      ).and_return(false)
+
+      post :suspend, params: { id: contractor.id, reason: "late invoices" }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(contractor.contractor_status_events.count).to eq(0)
+      expect(onboard.reload.suspended_at).to be_nil
+    end
+  end
+
+  describe "POST #unsuspend" do
+    before do
+      onboard.update!(
+        suspended_at: Time.current,
+        suspended_reason: "prior reason",
+        suspended_by: admin_user
+      )
+    end
+
+    it "unsuspends and records an unsuspend event with no reason" do
+      post :unsuspend, params: { id: contractor.id }
+
+      expect(response).to have_http_status(:success)
+      event = contractor.contractor_status_events.order(:created_at).last
+      expect(event.event_type).to eq("unsuspend")
+      expect(event.reason).to be_nil
+      expect(event.performed_by_id).to eq(admin_user.id)
+      expect(onboard.reload.suspended_at).to be_nil
+    end
+  end
+
+  describe "POST #deactivate" do
+    it "removes and records a remove event with reason" do
+      post :deactivate, params: { id: contractor.id, reason: "business closed" }
+
+      expect(response).to have_http_status(:success)
+      event = contractor.contractor_status_events.order(:created_at).last
+      expect(event.event_type).to eq("remove")
+      expect(event.reason).to eq("business closed")
+      expect(onboard.reload.deactivated_at).to be_present
+    end
+  end
+
+  describe "GET #status_history" do
+    let!(:suspend_event) do
+      ContractorStatusEvent.create!(
+        contractor: contractor,
+        contractor_onboard: onboard,
+        event_type: "suspend",
+        reason: "first",
+        performed_by: admin_user,
+        created_at: 2.hours.ago
+      )
+    end
+
+    let!(:unsuspend_event) do
+      ContractorStatusEvent.create!(
+        contractor: contractor,
+        contractor_onboard: onboard,
+        event_type: "unsuspend",
+        performed_by: admin_user,
+        created_at: 1.hour.ago
+      )
+    end
+
+    it "returns events newest-first" do
+      get :status_history, params: { id: contractor.id }
+
+      expect(response).to have_http_status(:success)
+      types = json_response["data"].map { |e| e["event_type"] }
+      expect(types).to eq(%w[unsuspend suspend])
+    end
+
+    it "is authorized for an admin_manager" do
+      sign_in admin_manager_user
+      get :status_history, params: { id: contractor.id }
+      expect(response).to have_http_status(:success)
+    end
+
+    it "is forbidden for a participant" do
+      sign_in participant_user
+      get :status_history, params: { id: contractor.id }
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end

--- a/spec/models/contractor_status_event_spec.rb
+++ b/spec/models/contractor_status_event_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe ContractorStatusEvent, type: :model do
+  let(:admin) do
+    User.create!(
+      first_name: "Admin",
+      last_name: "User",
+      email: "cse-admin@example.com",
+      password: "P@ssword1",
+      role: :admin,
+      confirmed_at: Time.current
+    )
+  end
+
+  let(:contractor) do
+    Contractor.create!(business_name: "Status Event Contractor", contact: admin)
+  end
+
+  let(:onboard_application) do
+    create(:permit_application, submitter: contractor)
+  end
+
+  let(:onboard) do
+    ContractorOnboard.create!(
+      contractor: contractor,
+      onboard_application: onboard_application
+    )
+  end
+
+  def build_event(attrs = {})
+    ContractorStatusEvent.new(
+      {
+        contractor: contractor,
+        contractor_onboard: onboard,
+        event_type: "suspend",
+        reason: "a reason",
+        performed_by: admin
+      }.merge(attrs)
+    )
+  end
+
+  it "is valid for each allowed event_type" do
+    ContractorStatusEvent::EVENT_TYPES.each do |type|
+      expect(build_event(event_type: type)).to be_valid
+    end
+  end
+
+  it "requires event_type" do
+    event = build_event(event_type: nil)
+    expect(event).not_to be_valid
+    expect(event.errors[:event_type]).to be_present
+  end
+
+  it "rejects an unknown event_type" do
+    event = build_event(event_type: "archive")
+    expect(event).not_to be_valid
+    expect(event.errors[:event_type]).to be_present
+  end
+
+  # Deliberately a faithful recorder: it never gates a status change, so it does
+  # not require a reason even for suspend/remove (that rule lives on the frontend).
+  it "allows a nil reason for every event_type" do
+    expect(build_event(event_type: "suspend", reason: nil)).to be_valid
+    expect(build_event(event_type: "unsuspend", reason: nil)).to be_valid
+    expect(build_event(event_type: "remove", reason: nil)).to be_valid
+  end
+
+  it "allows a nil performed_by (actor optional)" do
+    expect(build_event(performed_by: nil)).to be_valid
+  end
+end

--- a/spec/policies/contractor_policy_spec.rb
+++ b/spec/policies/contractor_policy_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe ContractorPolicy do
+  let(:sandbox) { nil }
+  let(:contractor) { Contractor.create!(business_name: "Policy Contractor") }
+
+  subject { described_class.new(UserContext.new(user, sandbox), contractor) }
+
+  describe "#status_history?" do
+    # Mirrors #suspend? - anyone who can suspend can view the history.
+    # Deliberately broader than AuditLogPolicy (which excludes plain admins),
+    # so an admin who can suspend can also see why.
+    context "roles that can suspend" do
+      %i[admin admin_manager].each do |role|
+        context "as #{role}" do
+          let(:user) { FactoryBot.create(:user, role: role) }
+          it "permits viewing history" do
+            expect(subject.status_history?).to be true
+          end
+        end
+      end
+    end
+
+    context "roles that cannot suspend" do
+      %i[participant contractor system_admin].each do |role|
+        context "as #{role}" do
+          let(:user) { FactoryBot.create(:user, role: role) }
+          it "denies viewing history" do
+            expect(subject.status_history?).to be false
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a permanent contractor_status_events table written app-side in the suspend/unsuspend/deactivate actions (transactional with the onboard update), plus a status_history endpoint and a "View status history" modal in contractor management. audit_logs is archived monthly, so it can't be the durable record; this table is. Also adds list semantics + grouped labels to the history modal and the internal-comments panel for screen readers.

Specs: model validations, ContractorPolicy#status_history? role matrix, and controller specs (event writes, transaction rollback, ordering, 403).