### PR TITLE
feat(BCHEP-732): make application-submitted notice editable via SiteC…

### DIFF
--- a/app/mailers/permit_hub_mailer.rb
+++ b/app/mailers/permit_hub_mailer.rb
@@ -17,6 +17,8 @@ class PermitHubMailer < ApplicationMailer
   def notify_submitter_application_submitted(permit_application, user)
     @user = user
     @permit_application = permit_application
+    @submission_notice =
+      SiteConfiguration.instance.try(:application_submission_notice)
 
     send_user_mail(
       email: @user.email,

--- a/app/views/permit_hub_mailer/notify_submitter_application_submitted.html.erb
+++ b/app/views/permit_hub_mailer/notify_submitter_application_submitted.html.erb
@@ -24,6 +24,10 @@
 </div>
 <!-- Button End -->
 
+<% if @submission_notice.present? %>
+<p><%= @submission_notice %></p>
+<% end %>
+
 <p>If we need more information, we will contact you by email.<br>If you have any questions, please call us at 1-833-856-0333 or email us at <a href="mailto:BetterHomesESP@CLEAResult.com">BetterHomesESP@CLEAResult.com</a>.</p>
 
 <p>Thank you,<br>Energy Savings Program Support</p>

--- a/db/migrate/20260722120000_add_application_submission_notice_to_site_configurations.rb
+++ b/db/migrate/20260722120000_add_application_submission_notice_to_site_configurations.rb
@@ -1,0 +1,23 @@
+class AddApplicationSubmissionNoticeToSiteConfigurations < ActiveRecord::Migration[
+  7.1
+]
+  # Blank is the column default; the notice text is seed data, not schema.
+  # We backfill the existing SiteConfiguration row here (rather than in a
+  # separate db/data migration) so the paragraph appears on deploy even if the
+  # pipeline does not run data migrations.
+  NOTICE =
+    "Due to the high volume of applications we are receiving, review and response times may be longer than usual. Applications are processed on a first come first serve basis. Estimated timelines for review are currently 45-60 days. Please be assured we will review your application as soon as we can."
+
+  def up
+    add_column :site_configurations, :application_submission_notice, :text
+
+    execute(<<~SQL.squish)
+      UPDATE site_configurations
+      SET application_submission_notice = #{connection.quote(NOTICE)}
+    SQL
+  end
+
+  def down
+    remove_column :site_configurations, :application_submission_notice
+  end
+end

--- a/db/migrate/20260722120000_add_application_submission_notice_to_site_configurations.rb
+++ b/db/migrate/20260722120000_add_application_submission_notice_to_site_configurations.rb
@@ -1,7 +1,8 @@
 class AddApplicationSubmissionNoticeToSiteConfigurations < ActiveRecord::Migration[
-  7.1
+  8.1
 ]
-  # Blank is the column default; the notice text is seed data, not schema.
+  # No column default (NULL), so the paragraph is hidden unless text is set;
+  # the notice text is seed data, not schema.
   # We backfill the existing SiteConfiguration row here (rather than in a
   # separate db/data migration) so the paragraph appears on deploy even if the
   # pipeline does not run data migrations.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_20_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_22_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -849,6 +849,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_20_120000) do
     t.string "sitewide_message_color"
     t.uuid "small_scale_requirement_template_id"
     t.datetime "updated_at", null: false
+    t.text "application_submission_notice"
     t.index ["small_scale_requirement_template_id"],
             name: "idx_on_small_scale_requirement_template_id_235b636c86"
   end

--- a/spec/mailers/permit_hub_mailer_spec.rb
+++ b/spec/mailers/permit_hub_mailer_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe PermitHubMailer, type: :mailer do
+  describe "#notify_submitter_application_submitted" do
+    let(:permit_application) { create(:permit_application, :newly_submitted) }
+    let(:user) { permit_application.submitter }
+
+    # The mailer skips unconfirmed users; the factory leaves users unconfirmed.
+    before { user.update!(confirmed_at: Time.current) }
+
+    subject(:body) do
+      mail =
+        described_class.notify_submitter_application_submitted(
+          permit_application,
+          user
+        )
+      (mail.html_part || mail).body.to_s
+    end
+
+    # A snippet unique to the DB-driven submission notice paragraph.
+    let(:notice_snippet) { "high volume of applications" }
+
+    context "when the submission notice is set" do
+      before do
+        SiteConfiguration.instance.update!(
+          application_submission_notice:
+            "Due to the high volume of applications, timelines are 45-60 days."
+        )
+      end
+
+      it "renders the notice paragraph" do
+        expect(body).to include(notice_snippet)
+      end
+    end
+
+    context "when the submission notice is blank" do
+      before do
+        SiteConfiguration.instance.update!(application_submission_notice: "")
+      end
+
+      it "omits the paragraph and still sends the email" do
+        expect(body).not_to include(notice_snippet)
+        expect(body).to include("View Application")
+      end
+    end
+
+    context "when the notice attribute is unavailable (stale schema cache)" do
+      before do
+        # A bare object does not respond to the attribute, so the mailer's
+        # `try(:application_submission_notice)` guard returns nil rather than
+        # raising. This mirrors the per-worker schema-cache race where the
+        # newly added column is not yet visible to a running process.
+        allow(SiteConfiguration).to receive(:instance).and_return(Object.new)
+      end
+
+      it "degrades gracefully without raising and still sends the email" do
+        expect { body }.not_to raise_error
+        expect(body).not_to include(notice_snippet)
+        expect(body).to include("View Application")
+      end
+    end
+  end
+end


### PR DESCRIPTION
…onfiguration

Move the "high volume / 45-60 day" paragraph out of the ERB template and into a new SiteConfiguration.application_submission_notice column so the text can change without a deploy. Blank column default (paragraph hidden); migration backfills the existing row so it shows on deploy. Mailer reads via try() to survive the schema-cache window; view renders only when present.