### PR TITLE
feat(BCHEP-737): retire remove-contractor action, gate eligibility va…

### DIFF
--- a/app/frontend/components/domains/contractor-management/contractor-program-resources-screen.tsx
+++ b/app/frontend/components/domains/contractor-management/contractor-program-resources-screen.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Container, Flex, Heading, Input, Link, Text, VStack } from '@chakra-ui/react';
 import { CheckCircle } from '@phosphor-icons/react';
 import { observer } from 'mobx-react-lite';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMst } from '../../../setup/root';
 import { EDescriptionPartType } from '../../../types/enums';
@@ -300,6 +300,14 @@ export const ContractorProgramResourcesScreen = observer(function ContractorProg
   const [checking, setChecking] = useState(false);
   const [checkError, setCheckError] = useState(false);
 
+  // BCHEP-737: if the contractor becomes suspended while 'checkEligibilityCode' is selected,
+  // reset to a safe category so the resource panel never indexes the (now-hidden) eligibility key.
+  useEffect(() => {
+    if (isContractorSuspended && selectedCategory === 'checkEligibilityCode') {
+      setSelectedCategory('addEmployees');
+    }
+  }, [isContractorSuspended, selectedCategory]);
+
   const handleCheckEligibility = async () => {
     const code = eligibilityCode.trim();
     if (!ELIGIBILITY_CODE_REGEX.test(code)) {
@@ -452,8 +460,7 @@ export const ContractorProgramResourcesScreen = observer(function ContractorProg
           </Box>
 
           {/* Right Content Area */}
-          {/* BCHEP-737: hide eligibility-code panel for suspended contractors (belt-and-suspenders; tab is also filtered out). */}
-          {selectedCategory === 'checkEligibilityCode' && !isContractorSuspended ? (
+          {selectedCategory === 'checkEligibilityCode' ? (
             <VStack
               flex={1}
               align="flex-start"

--- a/app/frontend/components/domains/contractor-management/contractor-program-resources-screen.tsx
+++ b/app/frontend/components/domains/contractor-management/contractor-program-resources-screen.tsx
@@ -4,11 +4,10 @@ import { observer } from 'mobx-react-lite';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMst } from '../../../setup/root';
-import CustomAlert from '../../shared/base/custom-alert';
-import { BlueTitleBar } from '../../shared/base/blue-title-bar';
-import { SubNavBar } from '../navigation/sub-nav-bar';
 import { EDescriptionPartType } from '../../../types/enums';
 import { DescriptionPart } from '../../../types/types';
+import { BlueTitleBar } from '../../shared/base/blue-title-bar';
+import CustomAlert from '../../shared/base/custom-alert';
 interface ProgramResource {
   id: string;
   title: string;
@@ -284,7 +283,13 @@ export const ContractorProgramResourcesScreen = observer(function ContractorProg
   hideBlueSection = false,
 }: ContractorProgramResourcesScreenProps) {
   const { t } = useTranslation();
-  const { environment } = useMst();
+  const { environment, userStore } = useMst();
+  const { currentUser } = userStore;
+  // BCHEP-737: suspended contractors (and their employees) may not use eligibility-code validation.
+  const isContractorSuspended = currentUser?.contractorSuspended ?? false;
+  const sidebarCategories = isContractorSuspended
+    ? SIDEBAR_CATEGORIES.filter((category) => category.key !== 'checkEligibilityCode')
+    : SIDEBAR_CATEGORIES;
   const [selectedCategory, setSelectedCategory] = useState<ResourceCategory>('addEmployees');
   const [eligibilityCode, setEligibilityCode] = useState('');
   const [checkResult, setCheckResult] = useState<{
@@ -398,7 +403,7 @@ export const ContractorProgramResourcesScreen = observer(function ContractorProg
             bg="greys.white"
           >
             <VStack align="stretch" spacing={0} role="tablist" overflow="visible">
-              {SIDEBAR_CATEGORIES.map((category) => (
+              {sidebarCategories.map((category) => (
                 <Box
                   key={category.key}
                   as="button"
@@ -447,7 +452,8 @@ export const ContractorProgramResourcesScreen = observer(function ContractorProg
           </Box>
 
           {/* Right Content Area */}
-          {selectedCategory === 'checkEligibilityCode' ? (
+          {/* BCHEP-737: hide eligibility-code panel for suspended contractors (belt-and-suspenders; tab is also filtered out). */}
+          {selectedCategory === 'checkEligibilityCode' && !isContractorSuspended ? (
             <VStack
               flex={1}
               align="flex-start"

--- a/app/frontend/components/domains/contractor-management/contractor-table-rows.tsx
+++ b/app/frontend/components/domains/contractor-management/contractor-table-rows.tsx
@@ -6,7 +6,6 @@ import {
   Eye,
   HourglassMedium,
   PencilSimple,
-  Trash,
   Users,
 } from '@phosphor-icons/react';
 import { observer } from 'mobx-react-lite';
@@ -311,22 +310,29 @@ export const ContractorRow = observer(({ contractor, status = 'active' }: Contra
                   >
                     {t('contractor.actions.viewStatusHistory')}
                   </MenuItem>
-                  <MenuItem
-                    icon={<Trash />}
-                    onClick={handleRemove}
-                    color="red.500"
-                    role="menuitem"
-                    aria-label={`Remove contractor ${contractor.businessName}`}
-                    _focus={{ bg: 'red.50', outline: 'none' }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        handleRemove();
-                      }
-                    }}
-                  >
-                    {t('contractor.actions.removeContractor')}
-                  </MenuItem>
+                  {/*
+                    BCHEP-737: "Remove contractor" hidden per July 23, 2026 business decision.
+                    Contractor participation is now managed via Suspend / Unsuspend only.
+                    Backend deactivate flow (controller, route, reason page, store) is retained
+                    and re-enablable — do not delete. See ticket BCHEP-737.
+
+                    <MenuItem
+                      icon={<Trash />}
+                      onClick={handleRemove}
+                      color="red.500"
+                      role="menuitem"
+                      aria-label={`Remove contractor ${contractor.businessName}`}
+                      _focus={{ bg: 'red.50', outline: 'none' }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          handleRemove();
+                        }
+                      }}
+                    >
+                      {t('contractor.actions.removeContractor')}
+                    </MenuItem>
+                  */}
                 </>
               )}
 
@@ -378,22 +384,29 @@ export const ContractorRow = observer(({ contractor, status = 'active' }: Contra
                   >
                     {t('contractor.actions.viewStatusHistory')}
                   </MenuItem>
-                  <MenuItem
-                    icon={<Trash />}
-                    onClick={handleRemove}
-                    color="red.500"
-                    role="menuitem"
-                    aria-label={`Remove contractor ${contractor.businessName}`}
-                    _focus={{ bg: 'red.50', outline: 'none' }}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        handleRemove();
-                      }
-                    }}
-                  >
-                    {t('contractor.actions.removeContractor')}
-                  </MenuItem>
+                  {/*
+                    BCHEP-737: "Remove contractor" hidden per July 23, 2026 business decision.
+                    Contractor participation is now managed via Suspend / Unsuspend only.
+                    Backend deactivate flow (controller, route, reason page, store) is retained
+                    and re-enablable — do not delete. See ticket BCHEP-737.
+
+                    <MenuItem
+                      icon={<Trash />}
+                      onClick={handleRemove}
+                      color="red.500"
+                      role="menuitem"
+                      aria-label={`Remove contractor ${contractor.businessName}`}
+                      _focus={{ bg: 'red.50', outline: 'none' }}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          handleRemove();
+                        }
+                      }}
+                    >
+                      {t('contractor.actions.removeContractor')}
+                    </MenuItem>
+                  */}
                 </>
               )}
 

--- a/app/frontend/components/domains/contractor-management/index.tsx
+++ b/app/frontend/components/domains/contractor-management/index.tsx
@@ -1,22 +1,24 @@
-import { Box, Container, Flex, Heading, Tab, Tabs, TabList, TabPanel, TabPanels, VStack, Text } from '@chakra-ui/react';
+import { Box, Container, Flex, Heading, Tab, TabList, TabPanel, TabPanels, Tabs, Text, VStack } from '@chakra-ui/react';
 import { observer } from 'mobx-react-lite';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearch } from '../../../hooks/use-search';
+import { ISearch } from '../../../lib/create-search-model';
 import { IContractor } from '../../../models/contractor';
 import { useMst } from '../../../setup/root';
-import { SharedSpinner } from '../../shared/base/shared-spinner';
-import { SearchGrid } from '../../shared/grid/search-grid';
-import { ContractorGridHeaders } from './grid-header';
-import { ContractorRow } from './contractor-table-rows';
-import { ISearch } from '../../../lib/create-search-model';
 import { Paginator } from '../../shared/base/inputs/paginator';
 import { PerPageSelect } from '../../shared/base/inputs/per-page-select';
+import { SharedSpinner } from '../../shared/base/shared-spinner';
+import { SearchGrid } from '../../shared/grid/search-grid';
+import { ContractorRow } from './contractor-table-rows';
+import { ContractorGridHeaders } from './grid-header';
 
 export const ContractorManagementScreen = observer(function ContractorManagement() {
   const { t } = useTranslation();
   const { contractorStore } = useMst();
-  const statusToIndex = { active: 0, suspended: 1, removed: 2 };
+  // BCHEP-737: "Removed" tab retired from the UI (data retained in DB / store).
+  // Partial-typed so a stale 'removed' statusFilter still compiles and falls back to the Active tab (?? 0).
+  const statusToIndex: Partial<Record<'active' | 'suspended' | 'removed', number>> = { active: 0, suspended: 1 };
   const [tabIndex, setTabIndex] = useState(statusToIndex[contractorStore.statusFilter] ?? 0);
 
   const { isSearching } = contractorStore;
@@ -31,7 +33,7 @@ export const ContractorManagementScreen = observer(function ContractorManagement
 
   const handleSetTabIndex = (index: number) => {
     setTabIndex(index);
-    const statusMap = ['active', 'suspended', 'removed'] as const;
+    const statusMap = ['active', 'suspended'] as const;
     contractorStore.setStatusFilter(statusMap[index]);
   };
 
@@ -94,37 +96,8 @@ export const ContractorManagementScreen = observer(function ContractorManagement
                 outline: 'none',
                 boxShadow: 'none',
               }}
-              _after={{
-                content: '""',
-                position: 'absolute',
-                right: 0,
-                top: '50%',
-                transform: 'translateY(-50%)',
-                height: '16px',
-                width: '1px',
-                bg: 'gray.300',
-              }}
             >
               {t('contractor.tabs.suspended', 'Suspended')}
-            </Tab>
-            <Tab
-              pl={4}
-              _selected={selectedTabStyles}
-              _focus={{
-                outline: 'none',
-                boxShadow: 'none',
-              }}
-              _focusVisible={{
-                outline: '2px solid',
-                outlineColor: 'theme.blue',
-                outlineOffset: '2px',
-              }}
-              _active={{
-                outline: 'none',
-                boxShadow: 'none',
-              }}
-            >
-              {t('contractor.tabs.removed', 'Removed')}
             </Tab>
           </TabList>
           <TabPanels as={Flex} direction="column" flex={1} overflowY="auto">
@@ -167,28 +140,6 @@ export const ContractorManagementScreen = observer(function ContractorManagement
                 ) : (
                   contractorStore.tableContractors.map((contractor: IContractor) => {
                     return <ContractorRow key={contractor.id} contractor={contractor} status="suspended" />;
-                  })
-                )}
-              </SearchGrid>
-              <TableControls contractorStore={contractorStore} />
-            </TabPanel>
-            {/* Removed contractors tab */}
-            <TabPanel flex={1} px={0}>
-              <SearchGrid templateColumns="1fr 1fr 1.2fr 1fr 1fr 120px">
-                <ContractorGridHeaders status="removed" />
-                {isSearching ? (
-                  <Flex py="50" gridColumn={'span 6'}>
-                    <SharedSpinner />
-                  </Flex>
-                ) : contractorStore.tableContractors.length === 0 ? (
-                  <Flex py="50" gridColumn={'span 6'} justifyContent="center">
-                    <Text color="gray.500" fontSize="md">
-                      {t('errors.noResults')}
-                    </Text>
-                  </Flex>
-                ) : (
-                  contractorStore.tableContractors.map((contractor: IContractor) => {
-                    return <ContractorRow key={contractor.id} contractor={contractor} status="removed" />;
                   })
                 )}
               </SearchGrid>

--- a/app/policies/eligibility_code_policy.rb
+++ b/app/policies/eligibility_code_policy.rb
@@ -1,5 +1,9 @@
 class EligibilityCodePolicy < ApplicationPolicy
   def check?
+    # BCHEP-737: suspended contractors (and employees of a suspended contractor)
+    # may not validate eligibility codes. contractor_suspended? covers both.
+    return false if user.contractor_suspended?
+
     user.contractor? || user.admin? || user.admin_manager? || user.system_admin?
   end
 end

--- a/spec/policies/eligibility_code_policy_spec.rb
+++ b/spec/policies/eligibility_code_policy_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe EligibilityCodePolicy do
+  let(:sandbox) { nil }
+
+  # The policy authorizes the :eligibility_code symbol (see Api::EligibilityCodesController#show).
+  subject do
+    described_class.new(UserContext.new(user, sandbox), :eligibility_code)
+  end
+
+  # Build a suspended contractor whose primary contact is `contact`.
+  # suspended? reads latest_onboard.suspended_at, so an onboard with suspended_at is required.
+  def create_suspended_contractor(contact:)
+    contractor =
+      Contractor.create!(
+        business_name: "Suspended Co #{SecureRandom.hex(4)}",
+        contact: contact
+      )
+    onboard_application =
+      FactoryBot.create(:permit_application, submitter: contractor)
+    ContractorOnboard.create!(
+      contractor: contractor,
+      onboard_application: onboard_application,
+      suspended_at: Time.current
+    )
+    contractor
+  end
+
+  describe "#check?" do
+    context "as a suspended contractor (primary contact)" do
+      let(:user) { FactoryBot.create(:user, role: :contractor) }
+      before { create_suspended_contractor(contact: user) }
+
+      it "denies eligibility-code validation" do
+        expect(subject.check?).to be false
+      end
+    end
+
+    context "as an employee of a suspended contractor" do
+      let(:user) { FactoryBot.create(:user, role: :contractor) }
+      let(:primary_contact) { FactoryBot.create(:user, role: :contractor) }
+
+      before do
+        contractor = create_suspended_contractor(contact: primary_contact)
+        ContractorEmployee.create!(contractor: contractor, employee: user)
+      end
+
+      it "denies eligibility-code validation" do
+        expect(subject.check?).to be false
+      end
+    end
+
+    context "as an active (non-suspended) contractor" do
+      let(:user) { FactoryBot.create(:user, role: :contractor) }
+
+      it "permits eligibility-code validation" do
+        expect(subject.check?).to be true
+      end
+    end
+
+    %i[admin admin_manager system_admin].each do |role|
+      context "as #{role}" do
+        let(:user) { FactoryBot.create(:user, role: role) }
+
+        it "permits eligibility-code validation" do
+          expect(subject.check?).to be true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
…lidation for suspended contractors

- Hide Remove Contractor menu action in both active/suspended row menus (backend deactivate flow retained)
- Remove the Removed status tab from contractor management
- Deny eligibility-code validation for suspended contractors: EligibilityCodePolicy#check? + hidden UI tab
- Add EligibilityCodePolicy spec (suspended contractor/employee denied, active/admins allowed)