### PR TITLE
feat(BCHEP-531): show suspended-contractor banner + view-suspension-r…

### DIFF
--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -163,12 +163,17 @@ class PermitApplicationBlueprint < Blueprinter::Base
       SubmitterBlueprint.render(pa.submitter, view: :minimal)
     end
 
-    # BCHEP-531: suspension timestamp of a contractor submitter (nil when not a
-    # suspended contractor). Drives the onboarding "contractor suspended" banner for
-    # admin/review staff — both the gate (presence) and the displayed date/time.
-    # nil (no query) for User submitters; one latest_onboard lookup for contractors.
+    # BCHEP-531: suspension timestamp of the submitting contractor (nil when not
+    # suspended). Drives the "contractor suspended" banner for admin/review staff on
+    # both onboarding (Contractor submitter) and invoices (User submitter, resolved to
+    # the user's suspended contractor). Both gate (presence) and displayed date/time.
+    # Suspension of the contractor this submission belongs to, driving the
+    # "contractor suspended" banner for admin/review staff on onboarding and invoices.
+    # Uses the app's authoritative resolver (contractor_for_invoice: the submitter
+    # itself for onboarding, else the submitting user's own/employer contractor) so an
+    # invoice reflects ITS contractor's suspension. nil unless that contractor is suspended.
     field :submitter_suspended_at do |pa, options|
-      pa.submitter.suspended_at if pa.submitter.is_a?(Contractor)
+      pa.contractor_for_invoice&.suspended_at
     end
 
     field :is_fully_loaded do |pa, options|

--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -163,6 +163,14 @@ class PermitApplicationBlueprint < Blueprinter::Base
       SubmitterBlueprint.render(pa.submitter, view: :minimal)
     end
 
+    # BCHEP-531: suspension timestamp of a contractor submitter (nil when not a
+    # suspended contractor). Drives the onboarding "contractor suspended" banner for
+    # admin/review staff — both the gate (presence) and the displayed date/time.
+    # nil (no query) for User submitters; one latest_onboard lookup for contractors.
+    field :submitter_suspended_at do |pa, options|
+      pa.submitter.suspended_at if pa.submitter.is_a?(Contractor)
+    end
+
     field :is_fully_loaded do |pa, options|
       true
     end

--- a/app/frontend/components/domains/contractor-management/contractor-table-rows.tsx
+++ b/app/frontend/components/domains/contractor-management/contractor-table-rows.tsx
@@ -507,7 +507,7 @@ export const ContractorRow = observer(({ contractor, status = 'active' }: Contra
       />
 
       <StatusHistoryModal
-        contractor={contractor}
+        contractorId={contractor.id}
         isOpen={isHistoryModalOpen}
         onClose={() => setIsHistoryModalOpen(false)}
       />

--- a/app/frontend/components/domains/contractor-management/status-history-modal.tsx
+++ b/app/frontend/components/domains/contractor-management/status-history-modal.tsx
@@ -11,8 +11,6 @@ import {
   ModalHeader,
   ModalOverlay,
   Spinner,
-  Tag,
-  TagLabel,
   Text,
   VStack,
 } from '@chakra-ui/react';
@@ -22,27 +20,21 @@ import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IContractor } from '../../../models/contractor';
 import { useMst } from '../../../setup/root';
-import { IContractorStatusEvent, TContractorStatusEventType } from '../../../types/types';
+import { IContractorStatusEvent } from '../../../types/types';
 
 interface IStatusHistoryModalProps {
   contractor: IContractor;
   isOpen: boolean;
   onClose: () => void;
+  // Optional heading override (e.g. "Suspension reasons" on the onboarding page).
+  // Defaults to the generic "Status history" used by contractor management.
+  title?: string;
 }
-
-// Uses the design system's semantic tokens (see styles/theme/foundations/
-// colors.ts) rather than raw Chakra colorSchemes, matching the app's other
-// status tags (e.g. preview-status-tag.tsx).
-const EVENT_TAG_COLORS: Record<TContractorStatusEventType, { bg: string; border: string }> = {
-  suspend: { bg: 'semantic.warningLight', border: 'semantic.warning' },
-  unsuspend: { bg: 'semantic.successLight', border: 'semantic.success' },
-  remove: { bg: 'semantic.errorLight', border: 'semantic.error' },
-};
 
 // Read-only modal listing the permanent suspend/unsuspend/remove history for a
 // contractor (backed by contractor_status_events). Fetches fresh each time it
 // opens; the events are not held in the store.
-export const StatusHistoryModal = observer(({ contractor, isOpen, onClose }: IStatusHistoryModalProps) => {
+export const StatusHistoryModal = observer(({ contractor, isOpen, onClose, title }: IStatusHistoryModalProps) => {
   const { t } = useTranslation();
   const { contractorStore } = useMst();
   const [events, setEvents] = useState<IContractorStatusEvent[]>([]);
@@ -77,16 +69,12 @@ export const StatusHistoryModal = observer(({ contractor, isOpen, onClose }: ISt
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} size="lg" scrollBehavior="inside">
+    <Modal isOpen={isOpen} onClose={onClose} size="lg">
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{t('contractor.statusHistory.title')}</ModalHeader>
+        <ModalHeader>{title ?? t('contractor.statusHistory.title')}</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
-          <Text fontSize="sm" color="text.secondary" mb={4}>
-            {t('contractor.statusHistory.subtitle', { name: contractor.businessName })}
-          </Text>
-
           {isLoading ? (
             <Flex justify="center" py={8}>
               <Spinner aria-label={t('contractor.statusHistory.loading')} />
@@ -96,71 +84,58 @@ export const StatusHistoryModal = observer(({ contractor, isOpen, onClose }: ISt
           ) : events.length === 0 ? (
             <Text color="text.secondary">{t('contractor.statusHistory.empty')}</Text>
           ) : (
-            <VStack
-              as="ul"
-              role="list"
-              aria-label={t('contractor.statusHistory.listLabel')}
-              align="stretch"
-              spacing={3}
-              divider={<Divider as="li" aria-hidden="true" />}
-              listStyleType="none"
-              m={0}
-              p={0}
-            >
-              {events.map((event) => {
-                const eventLabel = t(`contractor.statusHistory.eventType.${event.eventType}`);
-                const actor = actorName(event);
-                const date = event.createdAt ? format(new Date(event.createdAt), 'yyyy-MM-dd HH:mm') : '';
-                // Group the tag/actor/date/reason fragments into one phrase so a
-                // screen reader announces each entry as a single coherent item.
-                const entryAria = event.reason
-                  ? t('contractor.statusHistory.entryAriaWithReason', {
-                      event: eventLabel,
-                      actor,
-                      date,
-                      reason: event.reason,
-                    })
-                  : t('contractor.statusHistory.entryAria', { event: eventLabel, actor, date });
-                return (
-                  <Box key={event.id} as="li" role="listitem" aria-label={entryAria}>
-                    {/* Visual detail is aria-hidden - the entry's aria-label above
-                        already conveys it as one phrase, avoiding double reading. */}
-                    <Flex align="center" gap={2} mb={1} wrap="wrap" aria-hidden="true">
-                      <Tag
-                        size="sm"
-                        borderRadius="0"
-                        variant="solid"
-                        bg={EVENT_TAG_COLORS[event.eventType].bg}
-                        border="1px solid"
-                        borderColor={EVENT_TAG_COLORS[event.eventType].border}
-                        color="text.primary"
-                        textTransform="uppercase"
-                      >
-                        <TagLabel fontWeight="bold">
-                          {t(`contractor.statusHistory.eventType.${event.eventType}`)}
-                        </TagLabel>
-                      </Tag>
-                      <Text fontSize="sm" color="text.secondary" mb={0}>
-                        {actorName(event)}
-                        {event.createdAt ? ` · ${format(new Date(event.createdAt), 'yyyy-MM-dd HH:mm')}` : ''}
+            <Box border="1px solid" borderColor="border.light" borderRadius="md" p={4} maxH="55vh" overflowY="auto">
+              <VStack
+                as="ul"
+                role="list"
+                aria-label={t('contractor.statusHistory.listLabel')}
+                align="stretch"
+                spacing={4}
+                divider={<Divider as="li" aria-hidden="true" />}
+                listStyleType="none"
+                m={0}
+                p={0}
+              >
+                {events.map((event) => {
+                  const eventLabel = t(`contractor.statusHistory.eventType.${event.eventType}`);
+                  const actor = actorName(event);
+                  const date = event.createdAt ? format(new Date(event.createdAt), 'MMM d, yyyy h:mm a') : '';
+                  // Group the fragments into one phrase so a screen reader announces
+                  // each entry as a single coherent item.
+                  const entryAria = event.reason
+                    ? t('contractor.statusHistory.entryAriaWithReason', {
+                        event: eventLabel,
+                        actor,
+                        date,
+                        reason: event.reason,
+                      })
+                    : t('contractor.statusHistory.entryAria', { event: eventLabel, actor, date });
+                  return (
+                    <Box key={event.id} as="li" role="listitem" aria-label={entryAria}>
+                      {/* Visual detail is aria-hidden - the entry's aria-label above
+                          already conveys it as one phrase, avoiding double reading. */}
+                      <Text fontSize="sm" fontWeight="bold" mb={0} aria-hidden="true">
+                        {date}:
                       </Text>
-                    </Flex>
-                    {event.reason ? (
-                      <Text fontSize="sm" whiteSpace="pre-wrap" mb={0} aria-hidden="true">
-                        <Text as="span" fontWeight="bold">
-                          {t('contractor.statusHistory.reasonLabel')}:{' '}
+                      {event.reason ? (
+                        <Text fontSize="sm" whiteSpace="pre-wrap" mt={2} mb={0} aria-hidden="true">
+                          {t('contractor.statusHistory.reasonLabel')}: {event.reason}
                         </Text>
-                        {event.reason}
+                      ) : null}
+                      <Text fontSize="sm" color="text.secondary" mt={2} mb={0} aria-hidden="true">
+                        {eventLabel} {t('contractor.statusHistory.byLabel')}: {actor}
                       </Text>
-                    ) : null}
-                  </Box>
-                );
-              })}
-            </VStack>
+                    </Box>
+                  );
+                })}
+              </VStack>
+            </Box>
           )}
         </ModalBody>
-        <ModalFooter>
-          <Button onClick={onClose}>{t('contractor.statusHistory.close')}</Button>
+        <ModalFooter justifyContent="flex-start">
+          <Button variant="secondary" onClick={onClose}>
+            {t('contractor.statusHistory.close')}
+          </Button>
         </ModalFooter>
       </ModalContent>
     </Modal>

--- a/app/frontend/components/domains/contractor-management/status-history-modal.tsx
+++ b/app/frontend/components/domains/contractor-management/status-history-modal.tsx
@@ -42,6 +42,13 @@ export const StatusHistoryModal = observer(({ contractorId, isOpen, onClose, tit
 
   useEffect(() => {
     if (!isOpen) return;
+    // Guard: without a contractor id there is nothing to fetch — clear any stale
+    // events and skip the request rather than calling /contractors//status_history.
+    if (!contractorId) {
+      setEvents([]);
+      setIsLoading(false);
+      return;
+    }
     let active = true;
     setIsLoading(true);
     setHasError(false);

--- a/app/frontend/components/domains/contractor-management/status-history-modal.tsx
+++ b/app/frontend/components/domains/contractor-management/status-history-modal.tsx
@@ -18,12 +18,11 @@ import { format } from 'date-fns';
 import { observer } from 'mobx-react-lite';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { IContractor } from '../../../models/contractor';
 import { useMst } from '../../../setup/root';
 import { IContractorStatusEvent } from '../../../types/types';
 
 interface IStatusHistoryModalProps {
-  contractor: IContractor;
+  contractorId: string;
   isOpen: boolean;
   onClose: () => void;
   // Optional heading override (e.g. "Suspension reasons" on the onboarding page).
@@ -34,7 +33,7 @@ interface IStatusHistoryModalProps {
 // Read-only modal listing the permanent suspend/unsuspend/remove history for a
 // contractor (backed by contractor_status_events). Fetches fresh each time it
 // opens; the events are not held in the store.
-export const StatusHistoryModal = observer(({ contractor, isOpen, onClose, title }: IStatusHistoryModalProps) => {
+export const StatusHistoryModal = observer(({ contractorId, isOpen, onClose, title }: IStatusHistoryModalProps) => {
   const { t } = useTranslation();
   const { contractorStore } = useMst();
   const [events, setEvents] = useState<IContractorStatusEvent[]>([]);
@@ -47,7 +46,7 @@ export const StatusHistoryModal = observer(({ contractor, isOpen, onClose, title
     setIsLoading(true);
     setHasError(false);
     contractorStore
-      .fetchStatusHistory(contractor.id)
+      .fetchStatusHistory(contractorId)
       .then((result: IContractorStatusEvent[]) => {
         if (active) setEvents(result ?? []);
       })
@@ -60,7 +59,7 @@ export const StatusHistoryModal = observer(({ contractor, isOpen, onClose, title
     return () => {
       active = false;
     };
-  }, [isOpen, contractor.id]);
+  }, [isOpen, contractorId]);
 
   const actorName = (event: IContractorStatusEvent) => {
     const user = event.performedBy;

--- a/app/frontend/components/domains/energy-savings-application/contractor-suspended-banner.tsx
+++ b/app/frontend/components/domains/energy-savings-application/contractor-suspended-banner.tsx
@@ -1,0 +1,42 @@
+import { Box, Flex } from '@chakra-ui/react';
+import { Warning } from '@phosphor-icons/react';
+import { format } from 'date-fns';
+import { observer } from 'mobx-react-lite';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface IContractorSuspendedBannerProps {
+  suspendedAt: Date;
+}
+
+// BCHEP-531: admin/review-staff banner shown above the form status flow on a suspended
+// contractor's onboarding (application edit) page. Matches the width of the status-flow box
+// because it is rendered in the same container via RequirementForm's renderTopButtons.
+// The "view suspension reasons" action lives in the page header, not in this banner.
+export const ContractorSuspendedBanner = observer(function ContractorSuspendedBanner({
+  suspendedAt,
+}: IContractorSuspendedBannerProps) {
+  const { t } = useTranslation();
+
+  // Matches the app-wide date/time format (e.g. the status-flow timeline): "Mar 2, 2026 4:03 PM"
+  const formattedDate = format(suspendedAt, 'MMM d, yyyy h:mm a');
+
+  return (
+    <Box
+      bg="theme.orangeLight02"
+      border="1px solid"
+      borderColor="theme.orange"
+      borderRadius="lg"
+      py={3}
+      px={4}
+      w="full"
+    >
+      <Flex direction="row" align="center" gap={2} w="full">
+        <Warning size={20} weight="fill" color="var(--chakra-colors-theme-orange)" style={{ flexShrink: 0 }} />
+        <Box fontFamily="BC Sans" fontWeight="400" fontSize="16px" lineHeight="27px" color="greys.anotherGrey">
+          {t('contractor.suspended.onboardingBanner.title', { date: formattedDate })}
+        </Box>
+      </Flex>
+    </Box>
+  );
+});

--- a/app/frontend/components/domains/energy-savings-application/edit-energy-savings-application-screen.tsx
+++ b/app/frontend/components/domains/energy-savings-application/edit-energy-savings-application-screen.tsx
@@ -10,7 +10,6 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { requirementTypeToFormioType } from '../../../constants';
 import { usePermitApplication } from '../../../hooks/resources/use-permit-application';
 import { useInterval } from '../../../hooks/use-interval';
-import { IContractor } from '../../../models/contractor';
 import { useMst } from '../../../setup/root';
 import { ICustomEventMap } from '../../../types/dom';
 import { ECollaborationType, ECustomEvents, EPermitApplicationStatus, ERequirementType } from '../../../types/enums';
@@ -320,7 +319,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
 
             {isSubmitted || isIneligible || isInReview || isAdminViewingContractorOnboarding ? (
               <Stack direction={{ base: 'column', lg: 'row' }} align={{ base: 'flex-end', lg: 'center' }}>
-                {currentPermitApplication?.submitterSuspendedAt && (
+                {isAdminViewingContractorOnboarding && currentPermitApplication?.submitterSuspendedAt && (
                   <Button variant="primary" onClick={onStatusHistoryOpen}>
                     {t('contractor.suspended.onboardingBanner.viewReasons')}
                   </Button>
@@ -462,7 +461,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
               formRef={formRef}
               permitApplication={currentPermitApplication}
               renderTopButtons={
-                currentPermitApplication?.submitterSuspendedAt
+                currentUser?.isReviewStaff && currentPermitApplication?.submitterSuspendedAt
                   ? () => <ContractorSuspendedBanner suspendedAt={currentPermitApplication!.submitterSuspendedAt!} />
                   : undefined
               }
@@ -499,9 +498,9 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
           permitApplication={currentPermitApplication}
         />
       )}
-      {currentPermitApplication?.submitter && (
+      {isAdminViewingContractorOnboarding && currentPermitApplication?.submitterSuspendedAt && (
         <StatusHistoryModal
-          contractor={currentPermitApplication.submitter as IContractor}
+          contractorId={currentPermitApplication?.submitter?.id ?? ''}
           isOpen={isStatusHistoryOpen}
           onClose={onStatusHistoryClose}
           title={t('contractor.statusHistory.suspensionReasonsTitle')}

--- a/app/frontend/components/domains/energy-savings-application/edit-energy-savings-application-screen.tsx
+++ b/app/frontend/components/domains/energy-savings-application/edit-energy-savings-application-screen.tsx
@@ -10,6 +10,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { requirementTypeToFormioType } from '../../../constants';
 import { usePermitApplication } from '../../../hooks/resources/use-permit-application';
 import { useInterval } from '../../../hooks/use-interval';
+import { IContractor } from '../../../models/contractor';
 import { useMst } from '../../../setup/root';
 import { ICustomEventMap } from '../../../types/dom';
 import { ECollaborationType, ECustomEvents, EPermitApplicationStatus, ERequirementType } from '../../../types/enums';
@@ -22,10 +23,12 @@ import { PermitApplicationSubmitModal } from '../../shared/energy-savings-applic
 import { RequirementForm } from '../../shared/energy-savings-applications/requirement-form';
 import { FloatingHelpDrawer } from '../../shared/floating-help-drawer';
 import SandboxHeader from '../../shared/sandbox/sandbox-header';
+import { StatusHistoryModal } from '../contractor-management/status-history-modal';
 import { BlockCollaboratorAssignmentManagement } from './assignment-management/block-collaborator-assignment-management';
 import { useCollaborationAssignmentNodes } from './assignment-management/hooks/use-collaboration-assignment-nodes';
 import { ChecklistSideBar } from './checklist-sidebar';
 import { ContactSummaryModal } from './contact-summary-modal';
+import { ContractorSuspendedBanner } from './contractor-suspended-banner';
 import { RevisionSideBar } from './revision-sidebar';
 import { SubmissionDownloadModal } from './submission-download-modal';
 //import { WithdrawApplicationModal } from './withdraw-application-modal';
@@ -58,6 +61,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
 
   const [completedBlocks, setCompletedBlocks] = useState({});
   const { isOpen: isContactsOpen, onOpen: onContactsOpen, onClose: onContactsClose } = useDisclosure();
+  const { isOpen: isStatusHistoryOpen, onOpen: onStatusHistoryOpen, onClose: onStatusHistoryClose } = useDisclosure();
 
   const [processEventOnLoad, setProcessEventOnLoad] = useState<CustomEvent | null>(null);
   const { requirementBlockAssignmentNodes, updateRequirementBlockAssignmentNode } = useCollaborationAssignmentNodes({
@@ -316,6 +320,11 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
 
             {isSubmitted || isIneligible || isInReview || isAdminViewingContractorOnboarding ? (
               <Stack direction={{ base: 'column', lg: 'row' }} align={{ base: 'flex-end', lg: 'center' }}>
+                {currentPermitApplication?.submitterSuspendedAt && (
+                  <Button variant="primary" onClick={onStatusHistoryOpen}>
+                    {t('contractor.suspended.onboardingBanner.viewReasons')}
+                  </Button>
+                )}
                 <SubmissionDownloadModal permitApplication={currentPermitApplication} />
                 <Button
                   rightIcon={<CaretRight />}
@@ -452,6 +461,11 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
             <RequirementForm
               formRef={formRef}
               permitApplication={currentPermitApplication}
+              renderTopButtons={
+                currentPermitApplication?.submitterSuspendedAt
+                  ? () => <ContractorSuspendedBanner suspendedAt={currentPermitApplication!.submitterSuspendedAt!} />
+                  : undefined
+              }
               onCompletedBlocksChange={setCompletedBlocks}
               triggerSave={handleSave}
               showHelpButton
@@ -483,6 +497,14 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
           onOpen={onContactsOpen}
           onClose={onContactsClose}
           permitApplication={currentPermitApplication}
+        />
+      )}
+      {currentPermitApplication?.submitter && (
+        <StatusHistoryModal
+          contractor={currentPermitApplication.submitter as IContractor}
+          isOpen={isStatusHistoryOpen}
+          onClose={onStatusHistoryClose}
+          title={t('contractor.statusHistory.suspensionReasonsTitle')}
         />
       )}
       {requirementBlockAssignmentNodes.map((requirementBlockAssignmentNode) => {

--- a/app/frontend/components/domains/energy-savings-application/review-permit-application-screen.tsx
+++ b/app/frontend/components/domains/energy-savings-application/review-permit-application-screen.tsx
@@ -370,7 +370,7 @@ export const ReviewPermitApplicationScreen = observer(() => {
                 {t('energySavingsApplication.show.supportingFilesRequest.addSupportingFiles')}
               </Button>
             )}
-            {currentPermitApplication?.submitterSuspendedAt && (
+            {isEditContractor && currentPermitApplication?.submitterSuspendedAt && (
               <Button variant="primary" onClick={onStatusHistoryOpen}>
                 {t('contractor.suspended.onboardingBanner.viewReasons')}
               </Button>
@@ -614,7 +614,7 @@ export const ReviewPermitApplicationScreen = observer(() => {
                           )}
                       </HStack>
                     )}
-                    {currentPermitApplication?.submitterSuspendedAt && (
+                    {isAdminUser && currentPermitApplication?.submitterSuspendedAt && (
                       <ContractorSuspendedBanner suspendedAt={currentPermitApplication.submitterSuspendedAt!} />
                     )}
                   </>
@@ -737,9 +737,9 @@ export const ReviewPermitApplicationScreen = observer(() => {
           permitApplication={currentPermitApplication}
         />
       )}
-      {currentPermitApplication?.submitter && (
+      {isEditContractor && currentPermitApplication?.submitterSuspendedAt && (
         <StatusHistoryModal
-          contractor={currentPermitApplication.submitter as IContractor}
+          contractorId={currentPermitApplication?.submitter?.id ?? ''}
           isOpen={isStatusHistoryOpen}
           onClose={onStatusHistoryClose}
           title={t('contractor.statusHistory.suspensionReasonsTitle')}

--- a/app/frontend/components/domains/energy-savings-application/review-permit-application-screen.tsx
+++ b/app/frontend/components/domains/energy-savings-application/review-permit-application-screen.tsx
@@ -21,10 +21,12 @@ import { ErrorScreen } from '../../shared/base/error-screen';
 import { LoadingScreen } from '../../shared/base/loading-screen';
 import { RequirementForm } from '../../shared/energy-savings-applications/requirement-form';
 import SandboxHeader from '../../shared/sandbox/sandbox-header';
+import { StatusHistoryModal } from '../contractor-management/status-history-modal';
 import { BlockCollaboratorAssignmentManagement } from './assignment-management/block-collaborator-assignment-management';
 import { useCollaborationAssignmentNodes } from './assignment-management/hooks/use-collaboration-assignment-nodes';
 import { ChecklistSideBar } from './checklist-sidebar';
 import { ContactSummaryModal } from './contact-summary-modal';
+import { ContractorSuspendedBanner } from './contractor-suspended-banner';
 import { InternalCommentsModal } from './internal-comments-modal';
 import { RevisionSideBar } from './revision-sidebar';
 import { SubmissionDownloadModal } from './submission-download-modal';
@@ -95,6 +97,7 @@ export const ReviewPermitApplicationScreen = observer(() => {
     onClose: onContractorApprovalClose,
   } = useDisclosure();
   const { isOpen: isContactsOpen, onOpen: onContactsOpen, onClose: onContactsClose } = useDisclosure();
+  const { isOpen: isStatusHistoryOpen, onOpen: onStatusHistoryOpen, onClose: onStatusHistoryClose } = useDisclosure();
   const { isOpen: isUpdatePathwayOpen, onOpen: onUpdatePathwayOpen, onClose: onUpdatePathwayClose } = useDisclosure();
   const {
     isOpen: isAddSupportingFilesPathwayOpen,
@@ -367,6 +370,11 @@ export const ReviewPermitApplicationScreen = observer(() => {
                 {t('energySavingsApplication.show.supportingFilesRequest.addSupportingFiles')}
               </Button>
             )}
+            {currentPermitApplication?.submitterSuspendedAt && (
+              <Button variant="primary" onClick={onStatusHistoryOpen}>
+                {t('contractor.suspended.onboardingBanner.viewReasons')}
+              </Button>
+            )}
             <SubmissionDownloadModal
               permitApplication={currentPermitApplication}
               review
@@ -470,140 +478,146 @@ export const ReviewPermitApplicationScreen = observer(() => {
               showSiteWarning={false}
               renderTopButtons={() => {
                 return (
-                  (!revisionMode || isEditContractor) && (
-                    <HStack spacing={6}>
-                      {!isEditContractor &&
-                        !(
-                          isInvoiceSubmission &&
-                          [
+                  <>
+                    {(!revisionMode || isEditContractor) && (
+                      <HStack spacing={6}>
+                        {!isEditContractor &&
+                          !(
+                            isInvoiceSubmission &&
+                            [
+                              EPermitApplicationStatus.approved,
+                              EPermitApplicationStatus.approvedPending,
+                              EPermitApplicationStatus.approvedPaid,
+                            ].includes(currentPermitApplication?.status)
+                          ) && (
+                            <Button
+                              variant="calloutInverse"
+                              leftIcon={<NotePencilIcon />}
+                              px={14}
+                              onClick={onUpdatePathwayOpen}
+                              borderColor="theme.yellow"
+                              isDisabled={
+                                currentPermitApplication?.status === EPermitApplicationStatus.ineligible ||
+                                (currentPermitApplication?.status === EPermitApplicationStatus.inReview &&
+                                  !isInvoiceSubmission)
+                              }
+                            >
+                              {t('energySavingsApplication.show.update')}
+                            </Button>
+                          )}
+                        {currentPermitApplication.submissionType?.code !== EPermitClassificationCode.onboarding &&
+                          ![
+                            EPermitApplicationStatus.inReview,
                             EPermitApplicationStatus.approved,
                             EPermitApplicationStatus.approvedPending,
                             EPermitApplicationStatus.approvedPaid,
-                          ].includes(currentPermitApplication?.status)
-                        ) && (
-                          <Button
-                            variant="calloutInverse"
-                            leftIcon={<NotePencilIcon />}
-                            px={14}
-                            onClick={onUpdatePathwayOpen}
-                            borderColor="theme.yellow"
-                            isDisabled={
-                              currentPermitApplication?.status === EPermitApplicationStatus.ineligible ||
-                              (currentPermitApplication?.status === EPermitApplicationStatus.inReview &&
-                                !isInvoiceSubmission)
-                            }
-                          >
-                            {t('energySavingsApplication.show.update')}
-                          </Button>
-                        )}
-                      {currentPermitApplication.submissionType?.code !== EPermitClassificationCode.onboarding &&
-                        ![
-                          EPermitApplicationStatus.inReview,
-                          EPermitApplicationStatus.approved,
-                          EPermitApplicationStatus.approvedPending,
-                          EPermitApplicationStatus.approvedPaid,
-                        ].includes(currentPermitApplication?.status) && (
-                          <Button
-                            variant="calloutInverse"
-                            leftIcon={<CheckCircleIcon />}
-                            px={14}
-                            onClick={onScreenIn}
-                            borderColor="green"
-                            isDisabled={currentPermitApplication?.status === EPermitApplicationStatus.ineligible}
-                          >
-                            {t('energySavingsApplication.show.screenIn')}
-                          </Button>
-                        )}
-                      {currentPermitApplication.submissionType?.code === EPermitClassificationCode.onboarding ? (
-                        currentPermitApplication?.status !== EPermitApplicationStatus.trainingPending ? (
-                          <Button
-                            variant="calloutInverse"
-                            px={14}
-                            onClick={onTrainingPending}
-                            borderColor="theme.darkGreen"
-                            bg="theme.lightGreen"
-                            _hover={{ bg: 'theme.lightGreen' }}
-                            _active={{ bg: 'theme.lightGreen' }}
-                            isDisabled={
-                              hasUnsavedEdits ||
-                              currentPermitApplication?.status === EPermitApplicationStatus.ineligible ||
-                              currentPermitApplication?.status === EPermitApplicationStatus.approved
-                            }
-                          >
-                            {t('energySavingsApplication.show.readyForTraining')}
-                          </Button>
-                        ) : (
-                          <Button
-                            variant="calloutInverse"
-                            px={14}
-                            onClick={onContractorApproval}
-                            borderColor="theme.darkGreen"
-                            bg="theme.lightGreen"
-                            _hover={{ bg: 'theme.lightGreen' }}
-                            _active={{ bg: 'theme.lightGreen' }}
-                            isDisabled={
-                              hasUnsavedEdits ||
-                              currentPermitApplication?.status === EPermitApplicationStatus.ineligible ||
-                              currentPermitApplication?.status === EPermitApplicationStatus.approved
-                            }
-                          >
-                            {t('ui.approve')}
-                          </Button>
-                        )
-                      ) : isInvoiceSubmission ? (
-                        currentPermitApplication?.status === EPermitApplicationStatus.approvedPending ? (
-                          <Button
-                            variant="calloutInverse"
-                            px={14}
-                            onClick={onMarkPaidOpen}
-                            borderColor="green"
-                            isDisabled={
-                              currentPermitApplication?.status !== EPermitApplicationStatus.approvedPending ||
-                              currentPermitApplication?.status === EPermitApplicationStatus.ineligible
-                            }
-                          >
-                            {t('energySavingsApplication.show.approvePaid')}
-                          </Button>
-                        ) : currentPermitApplication?.status === EPermitApplicationStatus.inReview ? (
-                          <Button
-                            variant="calloutInverse"
-                            px={14}
-                            onClick={onApprovePendingOpen}
-                            borderColor="green"
-                            isDisabled={
-                              currentPermitApplication?.status !== EPermitApplicationStatus.inReview ||
-                              currentPermitApplication?.status === EPermitApplicationStatus.ineligible
-                            }
-                          >
-                            {t('energySavingsApplication.show.approvePending')}
-                          </Button>
-                        ) : null
-                      ) : null}
-                      {!hasUnsavedEdits &&
-                        !(
-                          currentPermitApplication?.status === EPermitApplicationStatus.inReview && !isInvoiceSubmission
-                        ) &&
-                        currentPermitApplication?.status !== EPermitApplicationStatus.ineligible &&
-                        currentPermitApplication?.status !== EPermitApplicationStatus.approved &&
-                        currentPermitApplication?.status !== EPermitApplicationStatus.approvedPending &&
-                        currentPermitApplication?.status !== EPermitApplicationStatus.approvedPaid && (
-                          <Button
-                            variant="calloutInverse"
-                            leftIcon={!isEditContractor && <ProhibitIcon />}
-                            px={14}
-                            onClick={onIneligibleOpen}
-                            borderColor="semantic.errorDark"
-                            bg="theme.softRose"
-                            _hover={{ bg: 'theme.softRose' }}
-                            _active={{ bg: 'theme.softRose' }}
-                          >
-                            {!isEditContractor
-                              ? t('energySavingsApplication.show.inEligible')
-                              : t('energySavingsApplication.show.markIneligible')}
-                          </Button>
-                        )}
-                    </HStack>
-                  )
+                          ].includes(currentPermitApplication?.status) && (
+                            <Button
+                              variant="calloutInverse"
+                              leftIcon={<CheckCircleIcon />}
+                              px={14}
+                              onClick={onScreenIn}
+                              borderColor="green"
+                              isDisabled={currentPermitApplication?.status === EPermitApplicationStatus.ineligible}
+                            >
+                              {t('energySavingsApplication.show.screenIn')}
+                            </Button>
+                          )}
+                        {currentPermitApplication.submissionType?.code === EPermitClassificationCode.onboarding ? (
+                          currentPermitApplication?.status !== EPermitApplicationStatus.trainingPending ? (
+                            <Button
+                              variant="calloutInverse"
+                              px={14}
+                              onClick={onTrainingPending}
+                              borderColor="theme.darkGreen"
+                              bg="theme.lightGreen"
+                              _hover={{ bg: 'theme.lightGreen' }}
+                              _active={{ bg: 'theme.lightGreen' }}
+                              isDisabled={
+                                hasUnsavedEdits ||
+                                currentPermitApplication?.status === EPermitApplicationStatus.ineligible ||
+                                currentPermitApplication?.status === EPermitApplicationStatus.approved
+                              }
+                            >
+                              {t('energySavingsApplication.show.readyForTraining')}
+                            </Button>
+                          ) : (
+                            <Button
+                              variant="calloutInverse"
+                              px={14}
+                              onClick={onContractorApproval}
+                              borderColor="theme.darkGreen"
+                              bg="theme.lightGreen"
+                              _hover={{ bg: 'theme.lightGreen' }}
+                              _active={{ bg: 'theme.lightGreen' }}
+                              isDisabled={
+                                hasUnsavedEdits ||
+                                currentPermitApplication?.status === EPermitApplicationStatus.ineligible ||
+                                currentPermitApplication?.status === EPermitApplicationStatus.approved
+                              }
+                            >
+                              {t('ui.approve')}
+                            </Button>
+                          )
+                        ) : isInvoiceSubmission ? (
+                          currentPermitApplication?.status === EPermitApplicationStatus.approvedPending ? (
+                            <Button
+                              variant="calloutInverse"
+                              px={14}
+                              onClick={onMarkPaidOpen}
+                              borderColor="green"
+                              isDisabled={
+                                currentPermitApplication?.status !== EPermitApplicationStatus.approvedPending ||
+                                currentPermitApplication?.status === EPermitApplicationStatus.ineligible
+                              }
+                            >
+                              {t('energySavingsApplication.show.approvePaid')}
+                            </Button>
+                          ) : currentPermitApplication?.status === EPermitApplicationStatus.inReview ? (
+                            <Button
+                              variant="calloutInverse"
+                              px={14}
+                              onClick={onApprovePendingOpen}
+                              borderColor="green"
+                              isDisabled={
+                                currentPermitApplication?.status !== EPermitApplicationStatus.inReview ||
+                                currentPermitApplication?.status === EPermitApplicationStatus.ineligible
+                              }
+                            >
+                              {t('energySavingsApplication.show.approvePending')}
+                            </Button>
+                          ) : null
+                        ) : null}
+                        {!hasUnsavedEdits &&
+                          !(
+                            currentPermitApplication?.status === EPermitApplicationStatus.inReview &&
+                            !isInvoiceSubmission
+                          ) &&
+                          currentPermitApplication?.status !== EPermitApplicationStatus.ineligible &&
+                          currentPermitApplication?.status !== EPermitApplicationStatus.approved &&
+                          currentPermitApplication?.status !== EPermitApplicationStatus.approvedPending &&
+                          currentPermitApplication?.status !== EPermitApplicationStatus.approvedPaid && (
+                            <Button
+                              variant="calloutInverse"
+                              leftIcon={!isEditContractor && <ProhibitIcon />}
+                              px={14}
+                              onClick={onIneligibleOpen}
+                              borderColor="semantic.errorDark"
+                              bg="theme.softRose"
+                              _hover={{ bg: 'theme.softRose' }}
+                              _active={{ bg: 'theme.softRose' }}
+                            >
+                              {!isEditContractor
+                                ? t('energySavingsApplication.show.inEligible')
+                                : t('energySavingsApplication.show.markIneligible')}
+                            </Button>
+                          )}
+                      </HStack>
+                    )}
+                    {currentPermitApplication?.submitterSuspendedAt && (
+                      <ContractorSuspendedBanner suspendedAt={currentPermitApplication.submitterSuspendedAt!} />
+                    )}
+                  </>
                 );
               }}
               isEditing={
@@ -721,6 +735,14 @@ export const ReviewPermitApplicationScreen = observer(() => {
           onOpen={onContactsOpen}
           onClose={onContactsClose}
           permitApplication={currentPermitApplication}
+        />
+      )}
+      {currentPermitApplication?.submitter && (
+        <StatusHistoryModal
+          contractor={currentPermitApplication.submitter as IContractor}
+          isOpen={isStatusHistoryOpen}
+          onClose={onStatusHistoryClose}
+          title={t('contractor.statusHistory.suspensionReasonsTitle')}
         />
       )}
       {requirementBlockAssignmentNodes.map((requirementBlockAssignmentNode) => {

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -3297,11 +3297,13 @@ const options = {
           },
           statusHistory: {
             title: 'Status history',
+            suspensionReasonsTitle: 'Suspension reasons',
             subtitle: 'Suspend, unsuspend, and removal history for {{name}}.',
             loading: 'Loading history...',
             empty: 'No status history yet.',
             error: 'Could not load status history. Please try again.',
             reasonLabel: 'Reason',
+            byLabel: 'by',
             unknownActor: 'Unknown',
             close: 'Close',
             listLabel: 'Status change history',
@@ -3371,6 +3373,10 @@ const options = {
               title: 'Account suspended',
               message:
                 'You can only view past submissions and access program resources. You can not submit a new invoice until we unsuspend your account.',
+            },
+            onboardingBanner: {
+              title: 'Contractor suspended on {{date}}',
+              viewReasons: 'View suspension reasons',
             },
           },
           employees: {

--- a/app/frontend/models/energy-savings-application.ts
+++ b/app/frontend/models/energy-savings-application.ts
@@ -100,6 +100,7 @@ export const EnergySavingsApplicationModel = types.snapshotProcessor(
       statusUpdateReason: types.maybeNull(types.string),
       missingPdfs: types.maybeNull(types.array(types.string)),
       isFullyLoaded: types.optional(types.boolean, false),
+      submitterSuspendedAt: types.maybeNull(types.Date),
       isDirty: types.optional(types.boolean, false),
       isLoading: types.optional(types.boolean, false),
       indexedUsingCurrentTemplateVersion: types.maybeNull(types.boolean),


### PR DESCRIPTION
…easons on onboarding pages

- Expose submitter_suspended_at on the permit application :extended blueprint view
- Add "Contractor suspended on <date>" banner above the form status flow on the contractor onboarding edit and review screens (admin view)
- Add a "View suspension reasons" header button reusing StatusHistoryModal
- Restyle StatusHistoryModal to the "Suspension reasons" design (bold date, reason, performed-by line); optional title prop keeps "Status history" on contractor management