### PR TITLE
feat(BCHEP-531): Add an icon to suspended contractors in the submissi…

### DIFF
--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -148,6 +148,24 @@ class PermitApplicationBlueprint < Blueprinter::Base
     field :submitter do |pa, options|
       SubmitterBlueprint.render(pa.submitter, view: :minimal)
     end
+
+    # BCHEP-531 follow-up: suspension timestamp of the submitting contractor (nil when
+    # not suspended). Drives the suspended-contractor indicator in the submission inbox so
+    # review staff can spot those submissions without opening each row. Same authoritative
+    # resolver as the :extended detail banner (contractor_for_invoice: the submitter itself
+    # for onboarding, else the submitting user's own/employer contractor).
+    #
+    # Guard: only contractor submissions (onboarding + invoices) can have a suspended
+    # contractor, so skip the resolver for participant rows. user_group_type is eager-loaded
+    # (PROGRAM_SEARCH_INCLUDES), making this check free — and it keeps the participant inbox
+    # (all of prod today, since contractors aren't live yet) at zero added query cost.
+    field :submitter_suspended_at do |pa, options|
+      if pa.user_group_type&.code == "contractor"
+        pa.contractor_for_invoice&.suspended_at
+      else
+        nil
+      end
+    end
   end
 
   view :extended do

--- a/app/frontend/components/domains/programs/submission-inbox/grid-header.tsx
+++ b/app/frontend/components/domains/programs/submission-inbox/grid-header.tsx
@@ -10,9 +10,9 @@ import {
   EPermitClassificationCode,
 } from '../../../../types/enums';
 import { ModelSearchInput } from '../../../shared/base/model-search-input';
+import { EnergySavingsApplicationFilter } from '../../../shared/energy-savings-applications/energy-savings-application-filter';
 import { GridHeader } from '../../../shared/grid/grid-header';
 import { SortIcon } from '../../../shared/sort-icon';
-import { EnergySavingsApplicationFilter } from '../../../shared/energy-savings-applications/energy-savings-application-filter';
 
 export const GridHeaders = observer(function GridHeaders() {
   const { permitApplicationStore, userStore, permitClassificationStore, programStore } = useMst();
@@ -20,19 +20,21 @@ export const GridHeaders = observer(function GridHeaders() {
   const getSortColumnHeader = permitApplicationStore?.getSortColumnHeader;
   const currentUserId = userStore.currentUser?.id;
 
-
   // Don't render the filter if program is not set yet (prevents premature search on mount)
   if (!programStore.currentProgram) {
     return null;
   }
 
   // Filters now contain codes directly, not IDs
-  const submissionTypeCodes = permitApplicationStore.submissionTypeIdFilter ? [...permitApplicationStore.submissionTypeIdFilter] : [];
+  const submissionTypeCodes = permitApplicationStore.submissionTypeIdFilter
+    ? [...permitApplicationStore.submissionTypeIdFilter]
+    : [];
   const userGroupTypeCode = permitApplicationStore.userGroupTypeIdFilter;
 
   const isContractor = userGroupTypeCode === EPermitClassificationCode.contractor;
   const isOnboarding = submissionTypeCodes?.includes(EPermitClassificationCode.onboarding);
-  const isOnlyOnboarding = submissionTypeCodes?.length === 1 && submissionTypeCodes?.includes(EPermitClassificationCode.onboarding);
+  const isOnlyOnboarding =
+    submissionTypeCodes?.length === 1 && submissionTypeCodes?.includes(EPermitClassificationCode.onboarding);
 
   let statusGroups: EPermitApplicationStatusGroup[];
 
@@ -76,10 +78,7 @@ export const GridHeaders = observer(function GridHeaders() {
           <Flex justifyContent="flex-end" w="100%">
             <Flex gap={2} maxW="1000px" w="fit-content">
               <Box flex="1">
-                <EnergySavingsApplicationFilter
-                  key={filterKey}
-                  statusGroups={statusGroups}
-                />
+                <EnergySavingsApplicationFilter key={filterKey} statusGroups={statusGroups} />
               </Box>
               <Box flex="1">
                 <ModelSearchInput searchModel={permitApplicationStore} inputGroupProps={{ w: 'full' }} />
@@ -129,6 +128,10 @@ export const GridHeaders = observer(function GridHeaders() {
                   w={'full'}
                   as={'button'}
                   justifyContent={'space-between'}
+                  // Minimum gap between the label and the sort arrows. space-between alone
+                  // collapses to zero on content-sized (auto) columns, leaving the arrows
+                  // touching the header text; the gap floor keeps them separated there.
+                  gap={2}
                   cursor="pointer"
                   onClick={() => permitApplicationStore.toggleSort(castField)}
                   borderRight={'1px solid'}
@@ -137,7 +140,10 @@ export const GridHeaders = observer(function GridHeaders() {
                 >
                   <Text textAlign="left">{getSortColumnHeader(castField)}</Text>
                   {EPermitApplicationReviewerSortFields[key] !== EPermitApplicationReviewerSortFields.actions && (
-                    <SortIcon<EPermitApplicationSortFields> field={castField} currentSort={permitApplicationStore.sort} />
+                    <SortIcon<EPermitApplicationSortFields>
+                      field={castField}
+                      currentSort={permitApplicationStore.sort}
+                    />
                   )}
                 </Flex>
               </GridHeader>

--- a/app/frontend/components/domains/programs/submission-inbox/program-submisson-inbox-screen.tsx
+++ b/app/frontend/components/domains/programs/submission-inbox/program-submisson-inbox-screen.tsx
@@ -1,5 +1,17 @@
-import { Badge, Box, Container, Flex, Heading, HStack, IconButton, Stack, Text, VStack } from '@chakra-ui/react';
-import { ChatCircle, Download } from '@phosphor-icons/react';
+import {
+  Badge,
+  Box,
+  Container,
+  Flex,
+  Heading,
+  HStack,
+  IconButton,
+  Stack,
+  Text,
+  Tooltip,
+  VStack,
+} from '@chakra-ui/react';
+import { ChatCircle, Download, Warning } from '@phosphor-icons/react';
 import { format } from 'date-fns';
 import { observer } from 'mobx-react-lite';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -224,7 +236,16 @@ export const ProgramSubmissionInboxScreen = observer(function ProgramSubmissionI
           </Box>
         </Flex>
 
-        <SearchGrid templateColumns="1.5fr repeat(6, 1fr)" mt={4}>
+        {/* Status, Reference #, Submission type and Assigned are content-sized (auto): status
+            tags and submission types are short bounded values, reference numbers are a fixed-width
+            format, and the Assigned column is used on a tiny fraction of submissions in practice —
+            so a fixed 1fr each just wastes width. The remaining 1fr columns (Submitter, Submitted,
+            Actions) hold the genuinely variable-width content and absorb the freed space.
+            Submitter gets the largest flexible share (2fr) so contractor/person names stay on one
+            line even on pages where a long status label (e.g. "Approved - Pending") widens the auto
+            Status column.
+            Order: Status, Reference #, Submission type, Submitter, Submitted, Assigned, Actions. */}
+        <SearchGrid templateColumns="auto auto auto 2fr 1fr auto 1fr" mt={4}>
           <GridHeaders />
 
           {isSearching ? (
@@ -266,6 +287,9 @@ const ApplicationItem = ({ permitApplication }: { permitApplication: IEnergySavi
   const { t } = useTranslation();
   const [newUser, setNewUser] = useState<IMinimalFrozenUser | null>(null);
 
+  const assignedUser = newUser ?? permitApplication?.assignedUsers?.[0];
+  const assigneeName = `${assignedUser?.firstName || ''} ${assignedUser?.lastName || ''}`.trim();
+
   return (
     <Box
       key={permitApplication.id}
@@ -279,8 +303,19 @@ const ApplicationItem = ({ permitApplication }: { permitApplication: IEnergySavi
       <SearchGridItem>{permitApplication.number}</SearchGridItem>
       <SearchGridItem wordBreak="break-word">{permitApplication?.submissionType?.name}</SearchGridItem>
       <SearchGridItem>
-        <Flex>
-          <Text fontWeight={700} flex={1}>
+        <Flex align="center" gap={1.5}>
+          {/* BCHEP-531 follow-up: flag submissions from a suspended contractor at a glance
+              (onboarding and invoices), via submitter_suspended_at on the :program_review_inbox
+              blueprint. Prefixes the name; the Submitter column is wide enough (2fr) that this
+              doesn't wrap. Tooltip + aria-label carry the "Suspended" label. */}
+          {permitApplication.submitterSuspendedAt && (
+            <Tooltip label={t('contractor.suspended.badge')} hasArrow>
+              <Box as="span" display="inline-flex" color="theme.orange" flexShrink={0}>
+                <Warning weight="fill" size={16} aria-label={t('contractor.suspended.badge')} />
+              </Box>
+            </Tooltip>
+          )}
+          <Text fontWeight={700}>
             {permitApplication.submittedFor ? permitApplication.submittedFor : permitApplication.submitter?.name}
           </Text>
         </Flex>
@@ -292,13 +327,14 @@ const ApplicationItem = ({ permitApplication }: { permitApplication: IEnergySavi
         </Flex>
       </SearchGridItem>
       <SearchGridItem>
-        <Flex>
-          <Text fontWeight={700} flex={1}>
-            {newUser
-              ? `${newUser?.firstName || ''} ${newUser?.lastName || ''}`.trim()
-              : `${permitApplication?.assignedUsers?.[0]?.firstName || ''} ${permitApplication?.assignedUsers?.[0]?.lastName || ''}`.trim()}
-          </Text>
-          <Box flex={1}>
+        {/* Name + avatar sit as a left-aligned group (SearchGridItem is justify=flex-start). The name
+            renders only when there's an assignee, so an empty name never adds a gap that pushes the
+            "+" right; when there's no assignee the trigger is nudged left (ml) to cancel the ghost
+            IconButton's internal icon inset, so the "+" glyph lines up flush under the "Assigned"
+            header. The avatar is fixed size (flexShrink={0}) so longer names use the full width. */}
+        <Flex align="center" gap={2}>
+          {assigneeName && <Text fontWeight={700}>{assigneeName}</Text>}
+          <Box flexShrink={0} ml={assigneeName ? 0 : -3}>
             <DesignatedCollaboratorAssignmentPopover
               permitApplication={permitApplication}
               collaborationType={ECollaborationType.review}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -921,7 +921,7 @@ const options = {
             permit_classification: 'Types',
             submitter: 'Submitter',
             submitted_at: 'Submitted',
-            submission_type: 'Submission type',
+            submission_type: 'Type',
             viewed_at: 'Viewed at',
             updated_at: 'Last Updated',
             status: 'Status',
@@ -3367,6 +3367,7 @@ const options = {
             },
           },
           suspended: {
+            badge: 'Suspended',
             buttonDisabled: 'Submit invoice - disabled due to suspension',
             message: 'Your contractor account is suspended. You cannot submit invoices at this time.',
             banner: {

--- a/app/models/contractor.rb
+++ b/app/models/contractor.rb
@@ -38,9 +38,15 @@ class Contractor < ApplicationRecord
 
   validates :business_name, presence: true
 
-  # Delegate status fields to latest contractor_onboard record
+  # Delegate status fields to latest contractor_onboard record.
+  # Use the loaded association when present (avoids re-querying on repeated calls and
+  # lets any eager-load pay off) — falls back to an ordered query otherwise.
   def latest_onboard
-    contractor_onboards.order(created_at: :desc).first
+    if contractor_onboards.loaded?
+      contractor_onboards.max_by(&:created_at)
+    else
+      contractor_onboards.order(created_at: :desc).first
+    end
   end
 
   def suspended_at


### PR DESCRIPTION
…on inbox

- Add a guarded submitter_suspended_at field to the :program_review_inbox blueprint; shows a Warning icon by the submitter name for suspended contractors (onboarding + invoices), matching the 531 detail banner
- Guard it on user_group_type so it only resolves for contractor submissions — participant rows (all of prod today) add zero query cost
- Add a loaded-association guard to Contractor#latest_onboard (no-op today, lets future eager-loading pay off)
- Inbox grid: content-size the Status / Reference # / Type / Assigned columns and give Submitter 2fr so names stay on one line
- Rename the "Submission type" header to "Type" so the auto column stops reserving header-width it doesn't need
- Add a gap between header labels and their sort arrows
- Assigned cell: fixed-size trigger, render the name only when assigned, and left-align the "+" flush under the header when there's no assignee