### PR TITLE
refactor(BCHEP-712): render EULA content as HTML instead of through Q…

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -206,7 +206,7 @@ class Api::UsersController < Api::ApplicationController
       # un-onboarded placeholder that has not accepted yet. Without this, any known contractor
       # id - including a real, onboarded one - could have consent recorded against it.
       if contractor.onboarded? || contractor.license_agreements.exists?
-        return render_error "misc.user_not_authorized_error"
+        return(render_error "misc.user_not_authorized_error", { status: 403 })
       end
 
       # Non-registered contractor accepting EULA

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -200,6 +200,15 @@ class Api::UsersController < Api::ApplicationController
     # Try to find contractor first, then user
     contractor = Contractor.find_by(id: account_id)
     if contractor
+      # This branch is unauthenticated - it exists only for the pre-login flow where
+      # contractors#shim has just created a placeholder contractor. Treat that contractor id
+      # like the single-use capability token in ContractorImport: only ever accept for a fresh,
+      # un-onboarded placeholder that has not accepted yet. Without this, any known contractor
+      # id - including a real, onboarded one - could have consent recorded against it.
+      if contractor.onboarded? || contractor.license_agreements.exists?
+        return render_error "misc.user_not_authorized_error"
+      end
+
       # Non-registered contractor accepting EULA
       contractor.license_agreements.create!(
         accepted_at: Time.current,

--- a/app/frontend/components/domains/contractor-dashboard/contractor-dashboard-screen.tsx
+++ b/app/frontend/components/domains/contractor-dashboard/contractor-dashboard-screen.tsx
@@ -1,12 +1,12 @@
-import { Box, Container, Flex, Skeleton, Tab, TabList, TabPanel, TabPanels, Tabs, VStack } from '@chakra-ui/react';
+import { Box, Container, Flex, Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react';
 import { observer } from 'mobx-react-lite';
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMst } from '../../../setup/root';
 import { EPermitClassificationCode } from '../../../types/enums';
+import { BlueTitleBar } from '../../shared/base/blue-title-bar';
 import { ContractorProgramResourcesScreen } from '../contractor-management/contractor-program-resources-screen';
 import { EnergySavingsApplicationIndexScreen } from '../energy-savings-application';
-import { BlueTitleBar } from '../../shared/base/blue-title-bar';
 
 export const ContractorDashboardScreen = observer(function ContractorDashboard() {
   const { t } = useTranslation();
@@ -28,7 +28,7 @@ export const ContractorDashboardScreen = observer(function ContractorDashboard()
   };
 
   return (
-    <Flex as="main" direction="column" w="full" bg="greys.white" pb="24" minH="100vh">
+    <Flex as="main" id="main-content" tabIndex={-1} direction="column" w="full" bg="greys.white" pb="24" minH="100vh">
       <BlueTitleBar title={t('landing.contractor.dashboard.title', 'Contractor portal')} />
 
       <Container maxW="container.lg" pb={4} flex="1">

--- a/app/frontend/components/domains/contractor-management/contractor-program-resources-screen.tsx
+++ b/app/frontend/components/domains/contractor-management/contractor-program-resources-screen.tsx
@@ -371,7 +371,13 @@ export const ContractorProgramResourcesScreen = observer(function ContractorProg
 
   return (
     <Flex
-      as="main"
+      // This renders both as its own route (/contractor-program-resources) and embedded
+      // inside the contractor dashboard, which has its own <main> and skip-link target.
+      // hideBlueSection is set only by the dashboard, so it doubles as "am I embedded":
+      // when embedded, stay a plain section so we don't nest <main> elements or steal the
+      // page's #main-content target.
+      as={hideBlueSection ? 'section' : 'main'}
+      {...(hideBlueSection ? {} : { id: 'main-content', tabIndex: -1 })}
       direction="column"
       w="full"
       bg={hideBlueSection ? 'white' : 'greys.grey04'}
@@ -406,8 +412,6 @@ export const ContractorProgramResourcesScreen = observer(function ContractorProg
             overflow="visible"
             role="navigation"
             aria-label="Resource categories"
-            id="main-content"
-            tabIndex={-1}
             bg="greys.white"
           >
             <VStack align="stretch" spacing={0} role="tablist" overflow="visible">

--- a/app/frontend/components/domains/eligibility-check/index.tsx
+++ b/app/frontend/components/domains/eligibility-check/index.tsx
@@ -176,7 +176,15 @@ export const EligibilityCheck = observer(() => {
       </Flex>
 
       {/* Content Section */}
-      <Container maxW="container.lg" pt={{ md: 12 }} px={{ lg: 8 }} pb={{ md: 12 }} id="main-content" tabIndex={-1}>
+      <Container
+        as="main"
+        maxW="container.lg"
+        pt={{ md: 12 }}
+        px={{ lg: 8 }}
+        pb={{ md: 12 }}
+        id="main-content"
+        tabIndex={-1}
+      >
         <VStack spacing={{ base: 4, md: 12 }} align="flex-start">
           <Flex direction={{ base: 'column', md: 'row' }} gap={{ base: 6, md: 12 }}>
             <Box position="relative">

--- a/app/frontend/components/domains/onboarding/eula/index.tsx
+++ b/app/frontend/components/domains/onboarding/eula/index.tsx
@@ -1,13 +1,11 @@
 import { Box, Button, Flex, Heading, VStack } from '@chakra-ui/react';
 import { t } from 'i18next';
 import { observer } from 'mobx-react-lite';
-import React, { Suspense, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { useMst, useServerAPI } from '../../../../setup/root';
-import { LoadingScreen } from '../../../shared/base/loading-screen';
-
-const Editor = React.lazy(() => import('../../../shared/editor/editor').then((module) => ({ default: module.Editor })));
+import { EulaContent } from '../../../shared/eula-content';
 
 export const EULAScreen = observer(function EULAScreen({ withClose }: { withClose?: boolean }) {
   const { userStore } = useMst();
@@ -64,49 +62,35 @@ export const EULAScreen = observer(function EULAScreen({ withClose }: { withClos
 
   return (
     <>
-      <VStack direction="column" spacing={8} py={20} w="full" h={`calc(100vh - ${navHeight}px)`}>
+      <VStack
+        as="main"
+        id="main-content"
+        tabIndex={-1}
+        direction="column"
+        spacing={8}
+        py={20}
+        w="full"
+        h={`calc(100vh - ${navHeight}px)`}
+      >
         <Heading as="h1" m={0} flex={0} flexBasis="auto" color="theme.blueAlt">
           {t('eula.title')}
         </Heading>
-        <Suspense fallback={<LoadingScreen />}>
-          {eula && (
-            <>
-              <Box
-                maxW="4xl"
-                w="full"
-                overflow="hidden"
-                sx={{
-                  '.quill': { height: '100%', overflow: 'auto' },
-                  '.quill .ql-container': {
-                    border: '1px solid',
-                    borderColor: 'border.light',
-                    borderRadius: '6px',
-                    fontFamily: 'BC Sans',
-                    fontSize: '16px',
-                    lineHeight: '27px',
-                    color: '#2D2D2D',
-                  },
-                  '.quill .ql-editor': {
-                    fontFamily: 'BC Sans',
-                    fontSize: '16px',
-                    lineHeight: '27px',
-                    color: '#2D2D2D',
-                    padding: '1rem',
-                  },
-                }}
-              >
-                <Editor htmlValue={eula.content} readonly modules={{ toolbar: false }} />
+        {eula && (
+          <>
+            <Box maxW="4xl" w="full" overflow="hidden">
+              <Box h="100%" overflow="auto" border="1px solid" borderColor="border.light" borderRadius="6px">
+                <EulaContent content={eula.content} p="1rem" />
               </Box>
-              {(userStore.currentUser && !userStore.currentUser.eulaAccepted) || !userStore.currentUser ? (
-                <form onSubmit={handleSubmit(onSubmit)} style={{ flex: 0, flexBasis: 'auto' }}>
-                  <Button variant="primary" type="submit" isLoading={isLoading} isDisabled={!isValid || isLoading}>
-                    {t('eula.accept')}
-                  </Button>
-                </form>
-              ) : null}
-            </>
-          )}
-        </Suspense>
+            </Box>
+            {(userStore.currentUser && !userStore.currentUser.eulaAccepted) || !userStore.currentUser ? (
+              <form onSubmit={handleSubmit(onSubmit)} style={{ flex: 0, flexBasis: 'auto' }}>
+                <Button variant="primary" type="submit" isLoading={isLoading} isDisabled={!isValid || isLoading}>
+                  {t('eula.accept')}
+                </Button>
+              </form>
+            ) : null}
+          </>
+        )}
       </VStack>
       {withClose && (
         <Flex

--- a/app/frontend/components/shared/eula-content.tsx
+++ b/app/frontend/components/shared/eula-content.tsx
@@ -1,0 +1,57 @@
+import { Box, BoxProps } from '@chakra-ui/react';
+import React from 'react';
+
+interface IEulaContentProps extends Omit<BoxProps, 'children' | 'dangerouslySetInnerHTML'> {
+  content: string;
+}
+
+/**
+ * Renders EULA content authored in `eulas/*.html`.
+ *
+ * The content is written by developers as files, seeded into the database by EulaUpdater, and
+ * sanitized server-side by EndUserLicenseAgreement (`sanitizable :content`) before it is ever
+ * stored - so it is trusted here. It is deliberately NOT rendered through the shared Quill
+ * `Editor`: Quill reparses HTML into its own model and silently drops anything it has no format
+ * for, which means the authored markup and the rendered markup diverge. Every EULA view uses
+ * this component so they stay in step.
+ *
+ * Styling hooks for content authors: the sanitizer allows `class` but strips `style`, so any
+ * presentation must be a class styled here rather than an inline style in the HTML file.
+ */
+export const EulaContent = ({ content, sx, ...boxProps }: IEulaContentProps) => (
+  <Box
+    dangerouslySetInnerHTML={{ __html: content }}
+    sx={{
+      fontFamily: 'BC Sans',
+      fontSize: '16px',
+      lineHeight: '27px',
+      color: '#2D2D2D',
+      '& p': { marginBottom: '1rem' },
+      // 2.5rem is the browser default indent for a list; Chakra's reset zeroes it, so set it back
+      '& ul, & ol': { marginBottom: '1rem', paddingLeft: '2.5rem' },
+      // nested lists indent a further step and tuck under their parent item
+      '& ul ul, & ul ol, & ol ul, & ol ol': { marginTop: '0.5rem', marginBottom: 0 },
+      '& li': { marginBottom: '0.5rem' },
+      // authoring hook: `class="eula-indent"` steps a block in, e.g. a lead-in line that
+      // introduces the list below it. The sanitizer strips `style` but allows `class`, so
+      // presentation in eulas/*.html has to go through named classes like this one.
+      '& .eula-indent': { paddingLeft: '1.25rem' },
+      '& b, & strong': { fontWeight: '700' },
+      '& i, & em': { fontStyle: 'italic' },
+      '& a': {
+        color: '#005C97',
+        textDecoration: 'underline',
+        '&:hover': { color: '#003f68' },
+      },
+      '& h1, & h2, & h3': {
+        fontFamily: 'BC Sans',
+        fontWeight: '700',
+        color: '#005C97',
+        marginBottom: '1rem',
+        marginTop: '1.5rem',
+      },
+      ...sx,
+    }}
+    {...boxProps}
+  />
+);

--- a/app/frontend/components/shared/modals/eula-view-modal.tsx
+++ b/app/frontend/components/shared/modals/eula-view-modal.tsx
@@ -1,19 +1,20 @@
 import {
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
-  ModalCloseButton,
-  Button,
-  Text,
-  Spinner,
   Box,
+  Button,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Spinner,
+  Text,
 } from '@chakra-ui/react';
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMst } from '../../../setup/root';
+import { EulaContent } from '../eula-content';
 
 interface IEulaViewModalProps {
   isOpen: boolean;
@@ -33,7 +34,7 @@ export const EulaViewModal: React.FC<IEulaViewModalProps> = ({ isOpen, onClose }
     try {
       await userStore.fetchEULA();
     } catch (err) {
-      setError(t('ui.error'));
+      setError(t('site.error'));
     } finally {
       setIsLoading(false);
     }
@@ -97,33 +98,7 @@ export const EulaViewModal: React.FC<IEulaViewModalProps> = ({ isOpen, onClose }
             </Text>
           )}
 
-          {userStore.eula && !isLoading && !error && (
-            <Box
-              dangerouslySetInnerHTML={{ __html: userStore.eula.content }}
-              sx={{
-                fontFamily: 'BC Sans',
-                fontSize: '16px',
-                lineHeight: '27px',
-                color: '#2D2D2D',
-                '& p': { marginBottom: '1rem' },
-                '& ul': { marginBottom: '1rem', paddingLeft: '1.5rem' },
-                '& li': { marginBottom: '0.5rem' },
-                '& b, & strong': { fontWeight: '700' },
-                '& a': {
-                  color: '#005C97',
-                  textDecoration: 'underline',
-                  '&:hover': { color: '#003f68' },
-                },
-                '& h1, & h2, & h3': {
-                  fontFamily: 'BC Sans',
-                  fontWeight: '700',
-                  color: '#005C97',
-                  marginBottom: '1rem',
-                  marginTop: '1.5rem',
-                },
-              }}
-            />
-          )}
+          {userStore.eula && !isLoading && !error && <EulaContent content={userStore.eula.content} />}
 
           {!isLoading && !error && !userStore.eula && (
             <Text textAlign="center" p={4} fontFamily="BC Sans" fontSize="16px" color="#2D2D2D">

--- a/app/frontend/components/shared/user-eulas.tsx
+++ b/app/frontend/components/shared/user-eulas.tsx
@@ -20,27 +20,27 @@ import {
   Tag,
   Text,
   useDisclosure,
-} from "@chakra-ui/react"
-import { WarningCircle } from "@phosphor-icons/react"
-import { format } from "date-fns"
-import { observer } from "mobx-react-lite"
-import React, { useMemo } from "react"
-import { useTranslation } from "react-i18next"
-import { useCurrentUserLicenseAgreements } from "../../hooks/resources/user-license-agreements"
-import { useMst } from "../../setup/root"
-import { colors } from "../../styles/theme/foundations/colors"
-import { ILicenseAgreement } from "../../types/types"
-import { ErrorScreen } from "./base/error-screen"
-import { SharedSpinner } from "./base/shared-spinner"
-import { Editor } from "./editor/editor"
-import { RouterLinkButton } from "./navigation/router-link-button"
+} from '@chakra-ui/react';
+import { WarningCircle } from '@phosphor-icons/react';
+import { format } from 'date-fns';
+import { observer } from 'mobx-react-lite';
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useCurrentUserLicenseAgreements } from '../../hooks/resources/user-license-agreements';
+import { useMst } from '../../setup/root';
+import { colors } from '../../styles/theme/foundations/colors';
+import { ILicenseAgreement } from '../../types/types';
+import { ErrorScreen } from './base/error-screen';
+import { SharedSpinner } from './base/shared-spinner';
+import { EulaContent } from './eula-content';
+import { RouterLinkButton } from './navigation/router-link-button';
 
 export const UserEulas = observer(function UserEulas() {
-  const { userStore } = useMst()
-  const { t } = useTranslation()
-  const currentUser = userStore.currentUser
-  const currentEulaAccepted = currentUser?.eulaAccepted
-  const { error, licenseAgreements, isLoading, currentEula } = useCurrentUserLicenseAgreements()
+  const { userStore } = useMst();
+  const { t } = useTranslation();
+  const currentUser = userStore.currentUser;
+  const currentEulaAccepted = currentUser?.eulaAccepted;
+  const { error, licenseAgreements, isLoading, currentEula } = useCurrentUserLicenseAgreements();
 
   const subContent = useMemo(() => {
     if (isLoading) {
@@ -48,135 +48,120 @@ export const UserEulas = observer(function UserEulas() {
         <Center>
           <SharedSpinner my={3} />
         </Center>
-      )
+      );
     }
 
     if (error) {
-      return <ErrorScreen error={error} />
+      return <ErrorScreen error={error} />;
     }
 
-    const acceptedLicenseAgreement = licenseAgreements?.find((la) => la.agreement?.id === currentEula?.id)
+    const acceptedLicenseAgreement = licenseAgreements?.find((la) => la.agreement?.id === currentEula?.id);
 
     return acceptedLicenseAgreement ? (
-      <Text color={"text.secondary"} fontSize={"sm"}>
-        {t("userEulas.acceptedOn", {
-          date: format(acceptedLicenseAgreement.acceptedAt, "MMM dd, yyy"),
-          time: format(acceptedLicenseAgreement.acceptedAt, "hh:mm"),
+      <Text color={'text.secondary'} fontSize={'sm'}>
+        {t('userEulas.acceptedOn', {
+          date: format(acceptedLicenseAgreement.acceptedAt, 'MMM dd, yyy'),
+          time: format(acceptedLicenseAgreement.acceptedAt, 'hh:mm'),
         })}
       </Text>
     ) : (
       <Tag
         as={HStack}
         spacing={1.5}
-        w={"fit-content"}
+        w={'fit-content'}
         px={2}
         py={1.5}
-        fontSize={"sm"}
-        border={"1px solid"}
-        borderColor={"semantic.error"}
-        bg={"semantic.errorLight"}
+        fontSize={'sm'}
+        border={'1px solid'}
+        borderColor={'semantic.error'}
+        bg={'semantic.errorLight'}
       >
         <WarningCircle color={colors.semantic.error} />
-        <Text as={"span"}>{t("userEulas.actionRequired")}</Text>
+        <Text as={'span'}>{t('userEulas.actionRequired')}</Text>
       </Tag>
-    )
-  }, [isLoading, error, licenseAgreements, currentEula])
+    );
+  }, [isLoading, error, licenseAgreements, currentEula]);
 
   const pastLicenseAgreements = useMemo(() => {
-    return licenseAgreements?.filter((la) => la.agreement?.id !== currentEula?.id) ?? []
-  }, [isLoading, error, licenseAgreements, currentEula])
+    return licenseAgreements?.filter((la) => la.agreement?.id !== currentEula?.id) ?? [];
+  }, [isLoading, error, licenseAgreements, currentEula]);
 
   if (!isLoading && !error && !currentEula) {
-    return null
+    return null;
   }
 
   return (
     <HStack
-      as={"section"}
+      as={'section'}
       p={6}
-      border={"1px solid"}
-      borderColor={"border.light"}
-      borderRadius={"sm"}
-      justifyContent={"space-between"}
+      border={'1px solid'}
+      borderColor={'border.light'}
+      borderRadius={'sm'}
+      justifyContent={'space-between'}
     >
       <Stack flex={isLoading || error ? 1 : undefined} gap={currentEulaAccepted ? 1 : 2}>
         <HStack>
           <Heading as="h3" m={0}>
-            {t("userEulas.title")}
+            {t('userEulas.title')}
           </Heading>
           {pastLicenseAgreements.length > 0 && <PastEulasModal pastLicenseAgreements={pastLicenseAgreements} />}
         </HStack>
         {subContent}
       </Stack>
       {isLoading || error ? null : (
-        <RouterLinkButton to={"/profile/eula"} variant={currentEulaAccepted ? "secondary" : "primary"}>
-          {currentEulaAccepted ? t("userEulas.view") : t("userEulas.viewAgreement")}
+        <RouterLinkButton to={'/profile/eula'} variant={currentEulaAccepted ? 'secondary' : 'primary'}>
+          {currentEulaAccepted ? t('userEulas.view') : t('userEulas.viewAgreement')}
         </RouterLinkButton>
       )}
     </HStack>
-  )
-})
+  );
+});
 
 export const PastEulasModal = observer(function PastEulasModal({
   pastLicenseAgreements,
 }: {
-  pastLicenseAgreements: ILicenseAgreement[]
+  pastLicenseAgreements: ILicenseAgreement[];
 }) {
-  const { t } = useTranslation()
-  const { isOpen, onOpen, onClose } = useDisclosure()
+  const { t } = useTranslation();
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
     <>
-      <Box fontSize={"sm"}>
+      <Box fontSize={'sm'}>
         (
-        <Button variant={"link"} onClick={onOpen}>
-          {t("userEulas.pastAgreementsModal.triggerButton")}
+        <Button variant={'link'} onClick={onOpen}>
+          {t('userEulas.pastAgreementsModal.triggerButton')}
         </Button>
         )
       </Box>
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
-        <ModalContent maxW={"800px"}>
-          <ModalHeader fontSize={"2xl"}>{t("userEulas.pastAgreementsModal.title")}</ModalHeader>
+        <ModalContent maxW={'800px'}>
+          <ModalHeader fontSize={'2xl'}>{t('userEulas.pastAgreementsModal.title')}</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
             <Accordion as={Stack} spacing={4} allowToggle allowMultiple>
               {pastLicenseAgreements.map((la) => (
                 <AccordionItem
-                  border={"1px solid"}
-                  borderColor={"border.light"}
-                  borderRadius={"sm"}
-                  bg={"greys.grey04"}
+                  border={'1px solid'}
+                  borderColor={'border.light'}
+                  borderRadius={'sm'}
+                  bg={'greys.grey04'}
                   key={la.id}
                 >
-                  <Box as={"h2"}>
-                    <AccordionButton fontWeight={"700"}>
+                  <Box as={'h2'}>
+                    <AccordionButton fontWeight={'700'}>
                       <Box as="span" flex="1" textAlign="left">
-                        {t("userEulas.pastAgreementsModal.acceptedOn", {
-                          timestamp: format(la.acceptedAt, "MMM dd, yyy hh:mm"),
+                        {t('userEulas.pastAgreementsModal.acceptedOn', {
+                          timestamp: format(la.acceptedAt, 'MMM dd, yyy hh:mm'),
                         })}
                       </Box>
                       <AccordionIcon />
                     </AccordionButton>
                   </Box>
-                  <AccordionPanel bg={"white"} borderBottomRadius={"sm"}>
-                    <Box
-                      maxW="4xl"
-                      overflow="hidden"
-                      sx={{
-                        ".quill": {
-                          height: "100%",
-                          overflow: "auto",
-                          ".ql-editor": {
-                            p: 0,
-                          },
-                          ".ql-container": {
-                            border: "none",
-                          },
-                        },
-                      }}
-                    >
-                      <Editor value={la.agreement?.content} readOnly={true} modules={{ toolbar: false }} />
+                  <AccordionPanel bg={'white'} borderBottomRadius={'sm'}>
+                    <Box maxW="4xl" overflow="hidden">
+                      <EulaContent content={la.agreement?.content ?? ''} />
                     </Box>
                   </AccordionPanel>
                 </AccordionItem>
@@ -184,13 +169,13 @@ export const PastEulasModal = observer(function PastEulasModal({
             </Accordion>
           </ModalBody>
 
-          <ModalFooter justifyContent={"flex-start"} mt={4}>
-            <Button variant={"primary"} onClick={onClose}>
-              {t("ui.close")}
+          <ModalFooter justifyContent={'flex-start'} mt={4}>
+            <Button variant={'primary'} onClick={onClose}>
+              {t('ui.close')}
             </Button>
           </ModalFooter>
         </ModalContent>
       </Modal>
     </>
-  )
-})
+  );
+});

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -612,7 +612,7 @@ const options = {
         },
         eula: {
           title: 'Terms and Conditions',
-          accept: 'Accept terms and conditions',
+          accept: 'Accept',
         },
         userEulas: {
           title: 'End user license agreement',
@@ -3162,6 +3162,7 @@ const options = {
             welcome: 'Welcome',
             contractor: 'Contractor',
             getSupport: 'Get support',
+            terms: 'Terms and Conditions',
             sitewideBanner: 'Site-wide banner',
             apiSettings: 'API settings',
             create: 'Create',

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -46,8 +46,13 @@ class ApplicationPolicy
       @scope = scope
     end
 
+    # Fail closed, matching Pundit's own generated default. A policy that is used with
+    # policy_scope must define its own Scope#resolve; inheriting a permissive `scope.all`
+    # here means any future index action on a model whose policy has no Scope silently
+    # returns the entire table, and verify_policy_scoped still passes because it only
+    # checks that policy_scope was called - not that it narrowed anything.
     def resolve
-      scope.all
+      raise NoMethodError, "You must define #resolve in #{self.class}"
     end
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -52,7 +52,7 @@ class ApplicationPolicy
     # returns the entire table, and verify_policy_scoped still passes because it only
     # checks that policy_scope was called - not that it narrowed anything.
     def resolve
-      raise NoMethodError, "You must define #resolve in #{self.class}"
+      raise NotImplementedError, "You must define #resolve in #{self.class}"
     end
   end
 end

--- a/db/migrate/20260730000000_reseed_eulas_after_renderer_change.rb
+++ b/db/migrate/20260730000000_reseed_eulas_after_renderer_change.rb
@@ -1,11 +1,5 @@
 class ReseedEulasAfterRendererChange < ActiveRecord::Migration[8.1]
-  def up
+  def change
     EulaUpdater.run
-  end
-
-  # Reseeding reads the current eulas/*.html files and overwrites the active
-  # agreement content in place; there is no prior content to restore.
-  def down
-    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20260730000000_reseed_eulas_after_renderer_change.rb
+++ b/db/migrate/20260730000000_reseed_eulas_after_renderer_change.rb
@@ -1,5 +1,11 @@
-class ReseedEulasAfterRendererChange < ActiveRecord::Migration[7.1]
-  def change
+class ReseedEulasAfterRendererChange < ActiveRecord::Migration[8.1]
+  def up
     EulaUpdater.run
+  end
+
+  # Reseeding reads the current eulas/*.html files and overwrites the active
+  # agreement content in place; there is no prior content to restore.
+  def down
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/migrate/20260730000000_reseed_eulas_after_renderer_change.rb
+++ b/db/migrate/20260730000000_reseed_eulas_after_renderer_change.rb
@@ -1,0 +1,5 @@
+class ReseedEulasAfterRendererChange < ActiveRecord::Migration[7.1]
+  def change
+    EulaUpdater.run
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_29_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_30_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"

--- a/eulas/contractor.html
+++ b/eulas/contractor.html
@@ -14,7 +14,7 @@
     </li>
   </ul>
 
-  <p>
+  <p class="eula-indent">
     By accepting this declaration, you indicate your intent to participate in the Program as a Registered Contractor. You also:
   </p>
 

--- a/eulas/terms.html
+++ b/eulas/terms.html
@@ -16,7 +16,7 @@
     </li>
   </ul>
 
-  <p>
+  <p class="eula-indent">
     By accepting these terms and conditions, you indicate your intent to participate in the Program, and as such:
   </p>
 
@@ -32,12 +32,12 @@
     </li>
     <li>
       Acknowledge that the Program Administrators may collect, use, and disclose your personal information in accordance with applicable laws, the Participant Terms and Conditions, and applicable privacy policies in accordance with the following:
+      <ul>
+        <li>
+          Province of British Columbia - Freedom of Information and Protection of Privacy Act, section 26(c). For more information, contact: Senior Energy Efficiency Coordinator - Residential at <a href="mailto:betterhomesbc@gov.bc.ca">betterhomesbc@gov.bc.ca</a><br>
+          PO Box 9314 Stn Prov Govt, 4th floor, 1810 Blanshard St., Victoria BC V8W 9N1
+        </li>
+      </ul>
     </li>
-    <ul>
-      <li>
-        Province of British Columbia - Freedom of Information and Protection of Privacy Act, section 26(c). For more information, contact: Senior Energy Efficiency Coordinator - Residential at <a href="mailto:betterhomesbc@gov.bc.ca">betterhomesbc@gov.bc.ca</a><br>
-        PO Box 9314 Stn Prov Govt, 4th floor, 1810 Blanshard St., Victoria BC V8W 9N1
-      </li>
-    </ul>
   </ul>
 </div>


### PR DESCRIPTION
…uill

Quill reparsed the authored HTML and dropped anything it had no format for, so the two EULA render paths needed opposite CSS for the same result. Adds a shared EulaContent component used by all three paths, and indents the T&C lead-in and bullet lists. Fixes terms.html's invalid nested <ul> and reseeds.

Also:
- shorten the accept button label to "Accept"; fix t('ui.error'), a key that never existed
- add the missing site.breadcrumb.terms key, so /terms shows "Terms and Conditions" instead of the generic missing-key fallback "Not found"
- point skip links at real <main> landmarks on four screens. One had the id on a navigation sidebar; contractor program resources is also embedded in the dashboard, so it now only claims the landmark when rendered standalone
- guard accept_eula's unauthenticated contractor branch, which accepted any contractor id
- restore ApplicationPolicy::Scope to Pundit's fail-closed default