### PR TITLE
fix(BCHEP-748): show newest internal comments first

### DIFF
--- a/app/controllers/api/internal_comments_controller.rb
+++ b/app/controllers/api/internal_comments_controller.rb
@@ -6,7 +6,10 @@ class Api::InternalCommentsController < Api::ApplicationController
     authorize @permit_application, :view_internal_comments?
 
     comments =
-      @permit_application.internal_comments.includes(:user).order(:created_at)
+      @permit_application
+        .internal_comments
+        .includes(:user)
+        .order(created_at: :desc)
 
     render_success comments,
                    nil,

--- a/app/frontend/stores/energy-savings-application-store.ts
+++ b/app/frontend/stores/energy-savings-application-store.ts
@@ -406,7 +406,7 @@ export const PermitApplicationStoreModel = types
       const { ok, data: response } = yield self.environment.api.createInternalComment(permitApplicationId, params);
       if (ok && response?.data) {
         const existing = self.internalCommentsMap.get(permitApplicationId) ?? [];
-        const updated = [...existing, response.data];
+        const updated = [response.data, ...existing];
         self.internalCommentsMap.set(permitApplicationId, updated);
         self.getPermitApplicationById(permitApplicationId)?.setInternalCommentsCount(updated.length);
         return response.data;

--- a/spec/controllers/api/internal_comments_controller_spec.rb
+++ b/spec/controllers/api/internal_comments_controller_spec.rb
@@ -32,6 +32,23 @@ RSpec.describe Api::InternalCommentsController, type: :controller do
       get :index, params: { permit_application_id: permit_application.id }
       expect(response).to have_http_status(:forbidden)
     end
+
+    it "returns newest comments first" do
+      older = comment
+      newer =
+        InternalComment.create!(
+          permit_application: permit_application,
+          user: admin,
+          body: "a newer note",
+          created_at: older.created_at + 1.hour
+        )
+
+      sign_in admin
+      get :index, params: { permit_application_id: permit_application.id }
+      expect(json_response["data"].map { |c| c["id"] }).to eq(
+        [newer.id, older.id]
+      )
+    end
   end
 
   describe "POST #create" do


### PR DESCRIPTION
- Order the internal_comments index query by created_at desc
- Prepend new comments in the store so a freshly-posted comment shows at the top without needing a refetch