### PR TITLE
fix(BCHEP-591): match onboarding success screen to content doc

### DIFF
--- a/app/frontend/components/domains/energy-savings-application/successful-submission.tsx
+++ b/app/frontend/components/domains/energy-savings-application/successful-submission.tsx
@@ -2,15 +2,15 @@ import { Box, Button, Container, Divider, Flex, Heading, Icon, Tag, Text, VStack
 import { CheckCircleIcon } from '@phosphor-icons/react';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
-import { useTranslation, Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 import { usePermitApplication } from '../../../hooks/resources/use-permit-application';
+import { useMst } from '../../../setup/root';
+import { EPermitApplicationStatus, EUpdateRoles } from '../../../types/enums';
+import { GreenLineSmall } from '../../shared/base/decorative/green-line-small';
 import { ErrorScreen } from '../../shared/base/error-screen';
 import { LoadingScreen } from '../../shared/base/loading-screen';
 import { RouterLinkButton } from '../../shared/navigation/router-link-button';
-import { useMst } from '../../../setup/root';
-import { useLocation } from 'react-router-dom';
-import { GreenLineSmall } from '../../shared/base/decorative/green-line-small';
-import { EPermitApplicationStatus, EUpdateRoles } from '../../../types/enums';
 
 // Successful Submission Screen
 export const SuccessfulSubmissionScreen = observer(() => {
@@ -58,9 +58,13 @@ export const SuccessfulSubmissionScreen = observer(() => {
           ? t('energySavingsApplication.new.staffSubmissionSuccess', {
               submissionType: submissionTypeLabel,
             })
-          : t('energySavingsApplication.new.submissionSuccess', {
-              submissionType: submissionTypeLabel,
-            });
+          : currentPermitApplication.isContractorOnboarding
+            ? t('contractorOnboarding.submissionSuccess', {
+                submissionType: submissionTypeLabel,
+              })
+            : t('energySavingsApplication.new.submissionSuccess', {
+                submissionType: submissionTypeLabel,
+              });
 
   const determinedMessage =
     performedBy === EUpdateRoles.staff ? message.charAt(0).toUpperCase() + message.slice(1) : message;
@@ -75,11 +79,7 @@ export const SuccessfulSubmissionScreen = observer(() => {
   // Override for contractor onboarding
   if (currentPermitApplication.isContractorOnboarding) {
     whatsNextHeadingKey = 'contractorOnboarding.whatsNext.heading';
-    whatsNextLineKeys = [
-      'contractorOnboarding.whatsNext.line1',
-      'contractorOnboarding.whatsNext.line2',
-      'contractorOnboarding.whatsNext.line3',
-    ];
+    whatsNextLineKeys = ['contractorOnboarding.whatsNext.line1', 'contractorOnboarding.whatsNext.line2'];
     whatsNextEmail = t('site.support.contractorSupportEmail');
   } else if (isContractorInvoice) {
     // Override for contractor invoice

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1095,16 +1095,15 @@ const options = {
           readyContractor: 'Ready to submit your registration details?',
           confirmationContractor:
             'By submitting your registration details you confirm that the information you provided was completed to the best of your knowledge and ability.',
-          submissionSuccess: 'You have submitted your details to the Energy Savings Program.',
+          submissionSuccess: 'Your {{ submissionType }} form has been submitted',
           whatsNext: {
             heading: "What's next?",
             line1:
-              'Please wait while we assess your registration details. We will email you once your registration is approved. If we need more information we will reach out via email.',
+              'Please wait while we assess your registration details. If we need more information, we will reach out to the email you registered with. We will email you with next steps once we have reviewed your submission.',
             line2:
-              'If you need to add, edit, or remove employees from your account in the future you will need to call us.',
-            line3: 'If you have any questions, please call us at 1-833-856-0333 or email us at <1>{{email}}</1>.',
+              'If you need to add, edit, or remove employees from your account in the future you will need to email us. If you have any questions, please call 833-856-0333 or email <1>{{email}}</1>.',
           },
-          returnToDashboard: 'Back to Contractor homepage',
+          returnToDashboard: 'Back to contractor homepage',
           trainingPending: {
             confirmReadyTitle: 'Ready to mark this contractor as training pending?',
             confirmReadyMessage: 'I confirm this {{submissionType}} form has all the required information.',


### PR DESCRIPTION
- Drop exclamation mark from onboarding submission heading only (other submission types keep it, since the key is shared)
- Merge "email us" and "call/email support" into one sentence in the What's next block, matching Figma
- Repurpose previously-unused contractorOnboarding.submissionSuccess key instead of adding a new one