### PR TITLE
fix(BCHEP-756): restore From header on Devise emails

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,7 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV["FROM_EMAIL"]
+  # An empty-but-present FROM_EMAIL yields a blank From header, which CHES rejects
+  # with 422. Fall back so notification mail can't be dropped that way.
+  default from: ENV["FROM_EMAIL"].presence || "no-reply@gov.bc.ca"
   layout "mailer"
 
   protected

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -1,5 +1,8 @@
 class CustomDeviseMailer < Devise::Mailer
-  default from: ENV["FROM_EMAIL"]
+  # This is now the only source of the From header (see devise_mail below), and an
+  # empty-but-present FROM_EMAIL is truthy, so it would sail through Devise's check
+  # and produce the same blank From that CHES rejects with 422.
+  default from: ENV["FROM_EMAIL"].presence || "no-reply@gov.bc.ca"
   layout "mailer"
 
   # If you wanted to override devise confirmation instructions do it here
@@ -33,9 +36,11 @@ class CustomDeviseMailer < Devise::Mailer
     mail_headers = headers_for(action, opts)
     @root_url = FrontendUrlHelper.root_url
 
+    # Do NOT pass `from:` here. Devise's headers_for deliberately omits :from when the
+    # mailer defines `default from:` (see Devise::Mailers::Helpers), so mail_headers[:from]
+    # is nil and passing it explicitly overrides the default with a blank From.
     mail(
       to: mail_headers[:to],
-      from: mail_headers[:from],
       subject:
         "#{I18n.t("application_mailer.subject_start")} - #{mail_headers[:subject]}",
       template_path: "devise/mailer",

--- a/spec/mailers/custom_devise_mailer_spec.rb
+++ b/spec/mailers/custom_devise_mailer_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe CustomDeviseMailer do
+  let(:user) { create(:user) }
+
+  # Devise 5's headers_for stopped supplying :from when the mailer declares
+  # `default from:`. devise_mail still forwarded that now-absent key, so the
+  # message went out with a blank From and CHES rejected it with a 422.
+  # These guard the header rather than the mechanism, so they keep working
+  # whichever way Devise chooses to supply it.
+  describe "the From header" do
+    it "is populated on confirmation instructions" do
+      mail = described_class.confirmation_instructions(user, "tok")
+
+      expect(mail.from).to be_present
+      expect(mail.from.first).to eq(described_class.default[:from])
+    end
+
+    it "is populated on invitation instructions" do
+      mail = described_class.invitation_instructions(user, "tok")
+
+      expect(mail.from).to be_present
+    end
+  end
+end


### PR DESCRIPTION
Devise 5's headers_for omits :from when a mailer declares `default from:`. devise_mail still forwarded that now-nil key, overriding the default with a blank From, which CHES rejects with 422 - silently dropping every confirmation, reconfirmation and invitation email since e248d5c. Dev and test only; the deployed prod image predates the upgrade.

Both mailers now fall back when FROM_EMAIL is present but empty: Devise 4 tested that with .present?, Devise 5 tests truthiness.