### PR TITLE
fix(BCHEP-756a): surface CHES delivery failures instead of swallowing…

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -5,7 +5,7 @@ KEYCLOAK_SECRET=
 KEYCLOAK_CLIENT=
 KEYCLOAK_AUTH_URL=
 
-FROM_EMAIL="no-reply@bc.gov.ca"
+FROM_EMAIL="no-reply@gov.bc.ca"
 SESSION_TIMEOUT_MINUTES=360
 
 CONSIGNO_URL=https://consignostub.dev-hous-permit-portal.com/stub/api/v1

--- a/.env_example.docker_compose
+++ b/.env_example.docker_compose
@@ -5,7 +5,7 @@ KEYCLOAK_SECRET=
 KEYCLOAK_CLIENT=
 KEYCLOAK_AUTH_URL=
 
-FROM_EMAIL="no-reply@bc.gov.ca"
+FROM_EMAIL="no-reply@gov.bc.ca"
 SESSION_TIMEOUT_MINUTES=360
 
 # Step code - You can remove this if you are forking the repo, but need to remove subsequent step cod related features.

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -8,6 +8,7 @@ class Api::ApplicationController < ActionController::API
   before_action :require_confirmation
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+  rescue_from ChesEmailDelivery::DeliveryError, with: :email_delivery_failed
 
   after_action :verify_authorized, except: %i[index], unless: :skip_pundit?
   after_action :verify_policy_scoped, only: %i[index], unless: :skip_pundit?
@@ -34,6 +35,14 @@ class Api::ApplicationController < ActionController::API
 
   def skip_pundit?
     devise_controller?
+  end
+
+  # Devise delivers its mail inline (send_devise_notification uses deliver_now), so a
+  # CHES rejection surfaces in whichever action triggered the send - invite!, a
+  # confirmation, a reconfirmation. Actions that can say something more specific
+  # rescue it themselves; this is the catch-all so the rest don't 500.
+  def email_delivery_failed(exception)
+    render_error("misc.email_delivery_failed", {}, exception) and return
   end
 
   def user_not_authorized(exception)

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -147,6 +147,10 @@ class Api::UsersController < Api::ApplicationController
                      }
                    }
     end
+  rescue ChesEmailDelivery::DeliveryError => e
+    # Devise sends the confirmation email from an after_commit hook, so the profile
+    # change is already saved when delivery fails. Say so rather than 500ing.
+    render_error("user.confirmation_email_failed", {}, e)
   end
 
   def license_agreements

--- a/config/initializers/mail_delivery_failures.rb
+++ b/config/initializers/mail_delivery_failures.rb
@@ -1,0 +1,14 @@
+# CHES rejections are permanent (malformed message, bad address), not transient, so
+# retrying wastes queue capacity and delivers nothing. Fail the job once, log it, and
+# discard rather than letting Sidekiq retry for ~21 days.
+#
+# User-facing sends (confirmation instructions) are delivered inline and surface the
+# failure to the user in Api::UsersController; this only governs queued mail.
+Rails.application.config.after_initialize do
+  ActionMailer::MailDeliveryJob.discard_on ChesEmailDelivery::DeliveryError do |job, error|
+    mailer, action = job.arguments.first(2)
+    Rails.logger.error(
+      "[CHES] Discarded #{mailer}##{action} after delivery failure: #{error.message}"
+    )
+  end
+end

--- a/config/initializers/mail_delivery_failures.rb
+++ b/config/initializers/mail_delivery_failures.rb
@@ -1,6 +1,11 @@
-# CHES rejections are permanent (malformed message, bad address), not transient, so
-# retrying wastes queue capacity and delivers nothing. Fail the job once, log it, and
-# discard rather than letting Sidekiq retry for ~21 days.
+# Fail queued mail once, log it, and discard rather than letting Sidekiq retry for
+# ~21 days. Every CHES rejection we have actually seen is permanent - a malformed
+# message or bad address fails identically however many times it is resent.
+#
+# This deliberately discards transient responses (429/5xx) too. A CHES outage fails
+# the health check in ChesEmailDelivery#deliver! before we ever get here and raises
+# a plain error, which Sidekiq does retry; and if CHES is down, a queued invite is
+# not the thing anyone will notice first.
 #
 # User-facing sends (confirmation instructions) are delivered inline and surface the
 # failure to the user in Api::UsersController; this only governs queued mail.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -367,6 +367,9 @@ en:
       reconfirmation_sent:
         title: Confirmation email sent
         message: Please click the link in your email inbox.
+      confirmation_email_failed:
+        title: Email could not be sent
+        message: Your changes were saved, but we could not send the confirmation email. Please try again, or contact support if the problem continues.
       reinvited:
         title: Invitation email sent
         message: ''
@@ -704,6 +707,9 @@ en:
       user_not_authorized_error:
         title: 'Unauthorized'
         message: 'The user is not authorized to do this action'
+      email_delivery_failed:
+        title: 'Email could not be sent'
+        message: 'The email could not be sent. Please try again, or contact support if the problem continues.'
       external_api_key_forbidden_error:
         title: 'Forbidden'
         message: 'The external api key is not authorized to do this action'

--- a/lib/ches_email_delivery.rb
+++ b/lib/ches_email_delivery.rb
@@ -1,4 +1,10 @@
 class ChesEmailDelivery
+  # Raised when CHES accepts the request but rejects the message (4xx/5xx).
+  # Surfacing this matters: a silently-swallowed 422 hid every Devise email
+  # failing for three weeks after the Devise 5 upgrade.
+  class DeliveryError < StandardError
+  end
+
   attr_accessor :config, :client, :bearer_token, :delivery_method
 
   def initialize(config)
@@ -39,7 +45,8 @@ class ChesEmailDelivery
       return body.dig("messages", 0, "msgId")
     else
       Rails.logger.error "[CHES] Failed to send email: #{response.status} #{response.body}"
-      #raise "CHES email delivery failed: #{response.status} #{response.body}"
+      raise DeliveryError,
+            "CHES email delivery failed: #{response.status} #{response.body}"
     end
   end
 

--- a/spec/controllers/api/users_profile_delivery_spec.rb
+++ b/spec/controllers/api/users_profile_delivery_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe Api::UsersController, type: :controller do
+  let(:user) { create(:user, :submitter) }
+
+  before { sign_in user }
+
+  def json_response
+    JSON.parse(response.body)
+  end
+
+  describe "PATCH #profile" do
+    context "when the confirmation email cannot be delivered" do
+      before do
+        allow_any_instance_of(ActionMailer::MessageDelivery).to receive(
+          :deliver_now
+        ).and_raise(
+          ChesEmailDelivery::DeliveryError.new(
+            "CHES email delivery failed: 422 Invalid value `from`"
+          )
+        )
+      end
+
+      it "tells the user the email could not be sent" do
+        patch :profile, params: { user: { email: "changed@example.com" } }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(json_response["meta"]["message"]["title"]).to eq(
+          "Email could not be sent"
+        )
+      end
+
+      # Devise sends the confirmation from an after_commit hook, so the record is
+      # already committed when delivery fails. The message says the changes were
+      # saved - this makes sure that stays true.
+      it "still persists the profile change" do
+        patch :profile, params: { user: { email: "changed@example.com" } }
+
+        expect(user.reload.unconfirmed_email).to eq("changed@example.com")
+      end
+    end
+  end
+
+  describe "POST #resend_confirmation" do
+    context "when the confirmation email cannot be delivered" do
+      before do
+        allow_any_instance_of(ActionMailer::MessageDelivery).to receive(
+          :deliver_now
+        ).and_raise(
+          ChesEmailDelivery::DeliveryError.new(
+            "CHES email delivery failed: 422 Invalid value `from`"
+          )
+        )
+      end
+
+      # No rescue in the action itself - this exercises the catch-all
+      # rescue_from in Api::ApplicationController.
+      it "falls back to the generic delivery failure message" do
+        post :resend_confirmation, params: { id: user.id }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(json_response["meta"]["message"]["title"]).to eq(
+          "Email could not be sent"
+        )
+        expect(json_response["meta"]["message"]["message"]).to eq(
+          "The email could not be sent. Please try again, or contact support if the problem continues."
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/ches_email_delivery_spec.rb
+++ b/spec/lib/ches_email_delivery_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe ChesEmailDelivery do
+  # Built with allocate so #initialize does not authenticate against CHES.
+  subject(:delivery) { described_class.allocate.tap { |d| d.client = client } }
+
+  let(:client) { instance_double(Faraday::Connection) }
+  let(:user) { create(:user) }
+  let(:mail) { CustomDeviseMailer.confirmation_instructions(user, "tok") }
+
+  before do
+    allow(delivery).to receive(
+      :ensure_ches_token_is_valid_and_health_check_passes
+    )
+    allow(client).to receive(:post).and_return(response)
+  end
+
+  context "when CHES accepts the message" do
+    let(:response) do
+      instance_double(
+        Faraday::Response,
+        success?: true,
+        body: { messages: [{ msgId: "abc-123" }] }.to_json
+      )
+    end
+
+    it "returns the message id" do
+      expect(delivery.deliver!(mail)).to eq("abc-123")
+    end
+  end
+
+  context "when CHES rejects the message" do
+    let(:response) do
+      instance_double(
+        Faraday::Response,
+        success?: false,
+        status: 422,
+        body: '{"detail":"Invalid value `from`"}'
+      )
+    end
+
+    # This used to be logged and swallowed, which hid every Devise email
+    # failing for three weeks after the Devise 5 upgrade.
+    it "raises DeliveryError rather than swallowing the failure" do
+      expect { delivery.deliver!(mail) }.to raise_error(
+        ChesEmailDelivery::DeliveryError,
+        /422/
+      )
+    end
+  end
+end

--- a/spec/mailers/custom_devise_mailer_spec.rb
+++ b/spec/mailers/custom_devise_mailer_spec.rb
@@ -9,17 +9,19 @@ RSpec.describe CustomDeviseMailer do
   # These guard the header rather than the mechanism, so they keep working
   # whichever way Devise chooses to supply it.
   describe "the From header" do
+    # mail[:from].to_s is the exact string ChesEmailDelivery#deliver! sends to
+    # CHES, so asserting on it tests the value that actually gets rejected.
     it "is populated on confirmation instructions" do
       mail = described_class.confirmation_instructions(user, "tok")
 
-      expect(mail.from).to be_present
+      expect(mail[:from].to_s).to be_present
       expect(mail.from.first).to eq(described_class.default[:from])
     end
 
     it "is populated on invitation instructions" do
       mail = described_class.invitation_instructions(user, "tok")
 
-      expect(mail.from).to be_present
+      expect(mail[:from].to_s).to be_present
     end
   end
 end


### PR DESCRIPTION
… them

ChesEmailDelivery logged rejections and returned, which is why a blank From header dropped every Devise email for three weeks unnoticed. It now raises DeliveryError.

Queued mail discards on it rather than retrying, since CHES rejections are permanent. Controllers render "Email could not be sent" instead of a 500; profile also says the change was saved, because Devise sends from an after_commit hook and the record is already committed.

Also fixes the reversed sender domain in the two env examples.