### PR TITLE
fix(BCHEP-759): make the remove-document control usable

### DIFF
--- a/app/frontend/components/shared/chefs/additional-formio/constant.ts
+++ b/app/frontend/components/shared/chefs/additional-formio/constant.ts
@@ -1,6 +1,12 @@
 export const FILE_UPLOAD_CHUNK_SIZE =
-  (import.meta.env.VITE_FILE_UPLOAD_CHUNK_SIZE && parseFloat(import.meta.env.VITE_FILE_UPLOAD_CHUNK_SIZE)) || 10
-export const FILE_UPLOAD_CHUNK_SIZE_IN_BYTES = FILE_UPLOAD_CHUNK_SIZE * 1024 * 1024
+  (import.meta.env.VITE_FILE_UPLOAD_CHUNK_SIZE && parseFloat(import.meta.env.VITE_FILE_UPLOAD_CHUNK_SIZE)) || 10;
+export const FILE_UPLOAD_CHUNK_SIZE_IN_BYTES = FILE_UPLOAD_CHUNK_SIZE * 1024 * 1024;
 export const FILE_UPLOAD_MAX_SIZE =
-  (import.meta.env.VITE_FILE_UPLOAD_MAX_SIZE && parseFloat(import.meta.env.VITE_FILE_UPLOAD_MAX_SIZE)) || 100
-export const MAX_NUMBER_OF_PARTS = FILE_UPLOAD_MAX_SIZE / FILE_UPLOAD_CHUNK_SIZE
+  (import.meta.env.VITE_FILE_UPLOAD_MAX_SIZE && parseFloat(import.meta.env.VITE_FILE_UPLOAD_MAX_SIZE)) || 100;
+export const MAX_NUMBER_OF_PARTS = FILE_UPLOAD_MAX_SIZE / FILE_UPLOAD_CHUNK_SIZE;
+// Mirrors the server-side whitelist in app/uploaders/file_uploader.rb. Enforced on both
+// sides for the same reason FILE_UPLOAD_MAX_SIZE is: the client check fails fast, the
+// server check is the one that counts. Form.io reads this as `filePattern`, which also
+// drives the file picker's accept filter and the browse control's accessible name.
+export const FILE_UPLOAD_ALLOWED_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.img', '.pdf', '.xlsx', '.xls', '.txt'];
+export const FILE_UPLOAD_FILE_PATTERN = FILE_UPLOAD_ALLOWED_EXTENSIONS.join(',');

--- a/app/frontend/components/shared/chefs/additional-formio/templates/file.js
+++ b/app/frontend/components/shared/chefs/additional-formio/templates/file.js
@@ -180,8 +180,12 @@ export const overrideFileTemplate = (ctx) => {
       // The allowed-types list is rendered visibly under the drop zone (.file-pattern-hint), so
       // it is announced from there. Repeating it here made screen readers say it twice. Only
       // mention it when there is no visible hint, i.e. when the pattern is unrestricted.
-      const filePatternText =
-        !ctx.component.filePattern || ctx.component.filePattern === '*' ? 'Any file types are allowed' : '';
+      const hasPatternHint = !!(ctx.component.filePattern && ctx.component.filePattern !== '*');
+      // The visible hint is a sibling of the browse link, so it is not part of that link's
+      // accessible name. Point at it with aria-describedby so assistive tech announces the
+      // allowed types on focus, without duplicating the text into the name itself.
+      const hintId = 'file-pattern-hint-' + ctx.instance.id;
+      const filePatternText = hasPatternHint ? '' : 'Any file types are allowed';
       const srOnlyText = ctx.t(
         'Browse to attach file for ' +
           ctx.component.label +
@@ -193,7 +197,9 @@ export const overrideFileTemplate = (ctx) => {
       __p +=
         '\n        ' +
         ((__t = ctx.t('or')) == null ? '' : __t) +
-        '\n        <a href="#" ref="fileBrowse" class="browse">\n          ' +
+        '\n        <a href="#" ref="fileBrowse" class="browse"' +
+        (hasPatternHint ? ' aria-describedby="' + hintId + '"' : '') +
+        '>\n          ' +
         ((__t = ctx.t('browse')) == null ? '' : __t) +
         '\n          <span class="sr-only">\n            ' +
         ((__t = srOnlyText) == null ? '' : __t) +
@@ -202,9 +208,11 @@ export const overrideFileTemplate = (ctx) => {
       // Allowed formats, visible. Previously this only existed inside the sr-only span above
       // (and in a `ctx.options.vpat`-gated div that is never enabled), so sighted users were
       // never told what the field accepts - the single biggest cause of failed uploads.
-      if (ctx.component.filePattern && ctx.component.filePattern !== '*') {
+      if (hasPatternHint) {
         __p +=
-          '\n      <div class="file-pattern-hint">' +
+          '\n      <div class="file-pattern-hint" id="' +
+          hintId +
+          '">' +
           ((__t = ctx.t('Allowed file types: ') + ctx.component.filePattern.split(',').join(', ')) == null ? '' : __t) +
           '</div>';
       }
@@ -247,21 +255,29 @@ export const overrideFileTemplate = (ctx) => {
       ((__t = status.status === 'error' ? ' has-error' : '') == null ? '' : __t) +
       '">\n    <div class="row">\n      <div class="fileName col-sm-10">' +
       ((__t = status.originalName) == null ? '' : __t);
-    // Only a failed upload can be dismissed. Dismissing one that is still in flight splices
-    // filesToSync.filesToUpload, and syncFiles() then fails its length check (File.js:1035)
-    // and returns before dataValue.push(...) - discarding the WHOLE batch from the form while
-    // every file is already in storage.
+    // A row is dismissible only once it has failed AND the whole sync has settled.
     //
-    // Note the test is for the terminal state, not for 'progress'. A file spends nearly all of
-    // its in-flight life at status 'info' (waitFileProcessing) covering the virus scan and the
-    // S3 PUT; 'progress' appears only at the very end, because our provider reports progress
-    // exactly once at 100% after the PUT returns (uploads.ts:33). Keying on 'progress' would
-    // leave the control live for almost the whole window.
+    // Dismissing before then does not stick: when syncFiles() finishes it rebuilds
+    // filesToSync.filesToUpload from the batch result (File.js:1041), so a row spliced out
+    // mid-sync simply reappears. Measured - splicing an entry at t=2000ms of a 5s upload had
+    // no lasting effect either way. A control that silently undoes itself is worse than no
+    // control, so nothing is offered until the queue is stable.
+    //
+    // Both halves of the test matter:
+    //   status === 'error' - a file spends nearly all its in-flight life at 'info'
+    //     (waitFileProcessing), covering the virus scan and the S3 PUT. 'progress' appears only
+    //     at the very end, because our provider reports progress once at 100% after the PUT
+    //     returns (uploads.ts:33). Keying on 'progress' leaves the control live almost the
+    //     whole time.
+    //   !ctx.isSyncing - upload() is a Promise.all (File.js:960), so one file can fail and
+    //     redraw its row while its siblings are still uploading. Measured at 5.25s for a 60kB
+    //     sibling on a throttled connection. syncFiles' finally block clears isSyncing and
+    //     redraws, which is what exposes the buttons.
     //
     // Formio's stock template offers an abort button here instead, but our provider never
     // calls abortCallback (s3custom.js:26) and uploadFileOneChunk uses fetch with no
     // AbortSignal, so it would do nothing.
-    if (status.status !== 'error') {
+    if (status.status !== 'error' || ctx.isSyncing) {
       __p += '\n        <button type="button" ref="fileToSyncRemove" hidden></button>';
     } else {
       __p +=
@@ -290,7 +306,7 @@ export const overrideFileTemplate = (ctx) => {
         '</span>\n            </div>\n          </div>\n        ';
     } else if (status.status === 'error') {
       __p +=
-        '\n          <div class="alert alert-danger">' +
+        '\n          <div class="alert alert-danger" role="alert">' +
         ((__t = ctx.t(status.message)) == null ? '' : __t) +
         '</div>\n        ';
     } else {

--- a/app/frontend/components/shared/chefs/additional-formio/templates/file.js
+++ b/app/frontend/components/shared/chefs/additional-formio/templates/file.js
@@ -25,7 +25,8 @@ export const overrideFileTemplate = (ctx) => {
     __p = '',
     __j = Array.prototype.join;
   const files = Array.isArray(ctx?.files) ? ctx.files : [];
-  const statuses = Array.isArray(ctx?.statuses) ? ctx.statuses : [];
+  // v5 removed `statuses`; the equivalent queue is filesToUpload (File.js render()).
+  const filesToUpload = Array.isArray(ctx?.filesToUpload) ? ctx.filesToUpload : [];
   const fileTypes = Array.isArray(ctx?.component?.fileTypes) ? ctx.component.fileTypes : [];
   function print() {
     __p += __j.call(arguments, '');
@@ -81,9 +82,11 @@ export const overrideFileTemplate = (ctx) => {
       __p += '\n      <li class="list-group-item">\n        <div class="row">\n          ';
       if (!ctx.disabled) {
         __p +=
-          '\n            <div class="col-md-1"><i tabindex="0" class="' +
+          '\n            <div class="col-md-1"><button type="button" class="' +
           ((__t = ctx.iconClass('remove')) == null ? '' : __t) +
-          '" ref="removeLink"></i></div>\n          ';
+          '" ref="removeLink"><span class="sr-only">' +
+          ((__t = ctx.t('Remove ') + (file.originalName || file.name)) == null ? '' : __t) +
+          '</span></button></div>\n          ';
       }
       __p += '\n          <div class="col-md-';
       if (ctx.self.hasTypes) {
@@ -137,9 +140,11 @@ export const overrideFileTemplate = (ctx) => {
         'px">\n          ';
       if (!ctx.disabled) {
         __p +=
-          '\n            <i tabindex="0" class="' +
+          '\n            <button type="button" class="' +
           ((__t = ctx.iconClass('remove')) == null ? '' : __t) +
-          '" ref="removeLink"></i>\n          ';
+          '" ref="removeLink"><span class="sr-only">' +
+          ((__t = ctx.t('Remove ') + (file.originalName || file.name)) == null ? '' : __t) +
+          '</span></button>\n          ';
       }
       __p += '\n        </span>\n      </div>\n    ';
     });
@@ -172,10 +177,11 @@ export const overrideFileTemplate = (ctx) => {
       }
       // --- KEY FIX: strip HTML from description before embedding in sr-only span ---
       const plainDescription = stripHtml(ctx.component.description);
+      // The allowed-types list is rendered visibly under the drop zone (.file-pattern-hint), so
+      // it is announced from there. Repeating it here made screen readers say it twice. Only
+      // mention it when there is no visible hint, i.e. when the pattern is unrestricted.
       const filePatternText =
-        !ctx.component.filePattern || ctx.component.filePattern === '*'
-          ? 'Any file types are allowed'
-          : ctx.t('Allowed file types: ') + ctx.component.filePattern;
+        !ctx.component.filePattern || ctx.component.filePattern === '*' ? 'Any file types are allowed' : '';
       const srOnlyText = ctx.t(
         'Browse to attach file for ' +
           ctx.component.label +
@@ -192,6 +198,16 @@ export const overrideFileTemplate = (ctx) => {
         '\n          <span class="sr-only">\n            ' +
         ((__t = srOnlyText) == null ? '' : __t) +
         '\n          </span>\n        </a>\n      <div ref="fileProcessingLoader" class="loader-wrapper">\n        <div class="loader text-center"></div>\n      </div>\n    </div>\n  ';
+
+      // Allowed formats, visible. Previously this only existed inside the sr-only span above
+      // (and in a `ctx.options.vpat`-gated div that is never enabled), so sighted users were
+      // never told what the field accepts - the single biggest cause of failed uploads.
+      if (ctx.component.filePattern && ctx.component.filePattern !== '*') {
+        __p +=
+          '\n      <div class="file-pattern-hint">' +
+          ((__t = ctx.t('Allowed file types: ') + ctx.component.filePattern.split(',').join(', ')) == null ? '' : __t) +
+          '</div>';
+      }
     } else {
       __p +=
         '\n    <div class="video-container">\n      <video class="video" autoplay="true" ref="videoPlayer" tabindex="-1"></video>\n    </div>\n    <button class="btn btn-primary" ref="takePictureButton"><i class="fa fa-camera"></i> ' +
@@ -203,24 +219,41 @@ export const overrideFileTemplate = (ctx) => {
     __p += '\n';
   }
   __p += '\n';
-  statuses.forEach(function (status) {
+  filesToUpload.forEach(function (status) {
+    // A client-side rejection (wrong type, too big, duplicate name) never left the browser -
+    // nothing was scanned, uploaded or attached. So it renders as a plain message, with no
+    // remove control and no file size: there is nothing to remove and nothing was measured.
+    // These are cleared automatically the next time the user picks a file.
+    if (status.isValidationError) {
+      const why = String(status.message || '').replace(/^File /, '');
+      __p +=
+        '\n  <div class="file-rejected alert alert-danger" role="alert">' +
+        ((__t = status.originalName || status.name) == null ? '' : __t) +
+        ' ' +
+        ((__t = ctx.t(why)) == null ? '' : __t) +
+        '</div>\n';
+      return;
+    }
+
+    // Anything else got as far as the network - it may have reached storage - so it keeps the
+    // dismissible row.
     __p +=
       '\n  <div class="file ' +
       ((__t = status.status === 'error' ? ' has-error' : '') == null ? '' : __t) +
-      '">\n    <div class="row">\n      <div class="fileName col-form-label col-sm-10">' +
+      '">\n    <div class="row">\n      <div class="fileName col-sm-10">' +
       ((__t = status.originalName) == null ? '' : __t) +
-      '\n        <i class="' +
+      '\n        <button type="button" class="' +
       ((__t = ctx.iconClass('remove')) == null ? '' : __t) +
-      '" ref="fileStatusRemove">\n          <span class="sr-only">' +
-      ((__t = ctx.t('Remove button. Press to remove ' + status.originalName || status.name + '.')) == null ? '' : __t) +
-      '</span>\n          <span class="sr-only">' +
-      ((__t = status.message ? status.message.replace(';', '.') : '') == null ? '' : __t) +
-      '</span>\n        </i>\n      </div>\n      <div class="fileSize col-form-label col-sm-2 text-right">' +
+      '" ref="fileToSyncRemove"><span class="sr-only">' +
+      ((__t = ctx.t('Dismiss message about ' + (status.originalName || status.name) + '.')) == null ? '' : __t) +
+      '</span></button>\n      </div>\n      <div class="fileSize col-sm-2 text-right">' +
       ((__t = ctx.fileSize(status.size)) == null ? '' : __t) +
       '</div>\n    </div>\n    <div class="row">\n      <div class="col-sm-12">\n        ';
     if (status.status === 'progress') {
       __p +=
-        '\n          <div class="progress">\n            <div class="progress-bar" role="progressbar" aria-valuenow="' +
+        '\n          <div class="progress">\n            <div class="progress-bar" role="progressbar" ref="progress" id="' +
+        ((__t = status.id) == null ? '' : __t) +
+        '" aria-valuenow="' +
         ((__t = status.progress) == null ? '' : __t) +
         '" aria-valuemin="0" aria-valuemax="100" style="width: ' +
         ((__t = status.progress) == null ? '' : __t) +
@@ -231,18 +264,11 @@ export const overrideFileTemplate = (ctx) => {
         '</span>\n            </div>\n          </div>\n        ';
     } else if (status.status === 'error') {
       __p +=
-        '\n          <div class="alert alert-danger bg-' +
-        ((__t = status.status) == null ? '' : __t) +
-        '">' +
+        '\n          <div class="alert alert-danger">' +
         ((__t = ctx.t(status.message)) == null ? '' : __t) +
         '</div>\n        ';
     } else {
-      __p +=
-        '\n          <div class="bg-' +
-        ((__t = status.status) == null ? '' : __t) +
-        '">' +
-        ((__t = ctx.t(status.message)) == null ? '' : __t) +
-        '</div>\n        ';
+      __p += '\n          <div>' + ((__t = ctx.t(status.message)) == null ? '' : __t) + '</div>\n        ';
     }
     __p += '\n      </div>\n    </div>\n  </div>\n';
   });

--- a/app/frontend/components/shared/chefs/additional-formio/templates/file.js
+++ b/app/frontend/components/shared/chefs/additional-formio/templates/file.js
@@ -219,6 +219,11 @@ export const overrideFileTemplate = (ctx) => {
     __p += '\n';
   }
   __p += '\n';
+  // INVARIANT: every entry in filesToUpload must render exactly one [ref="fileToSyncRemove"].
+  // Formio binds these controls by their position in the refs array and splices
+  // filesToUpload at that same index (File.js:394), so a row that renders no control shifts
+  // every later row's target and dismisses the wrong entry. Rows that must not offer the
+  // control render a hidden placeholder rather than omitting it.
   filesToUpload.forEach(function (status) {
     // A client-side rejection (wrong type, too big, duplicate name) never left the browser -
     // nothing was scanned, uploaded or attached. So it renders as a plain message, with no
@@ -231,7 +236,7 @@ export const overrideFileTemplate = (ctx) => {
         ((__t = status.originalName || status.name) == null ? '' : __t) +
         ' ' +
         ((__t = ctx.t(why)) == null ? '' : __t) +
-        '</div>\n';
+        '<button type="button" ref="fileToSyncRemove" hidden></button></div>\n';
       return;
     }
 
@@ -241,12 +246,33 @@ export const overrideFileTemplate = (ctx) => {
       '\n  <div class="file ' +
       ((__t = status.status === 'error' ? ' has-error' : '') == null ? '' : __t) +
       '">\n    <div class="row">\n      <div class="fileName col-sm-10">' +
-      ((__t = status.originalName) == null ? '' : __t) +
-      '\n        <button type="button" class="' +
-      ((__t = ctx.iconClass('remove')) == null ? '' : __t) +
-      '" ref="fileToSyncRemove"><span class="sr-only">' +
-      ((__t = ctx.t('Dismiss message about ' + (status.originalName || status.name) + '.')) == null ? '' : __t) +
-      '</span></button>\n      </div>\n      <div class="fileSize col-sm-2 text-right">' +
+      ((__t = status.originalName) == null ? '' : __t);
+    // Only a failed upload can be dismissed. Dismissing one that is still in flight splices
+    // filesToSync.filesToUpload, and syncFiles() then fails its length check (File.js:1035)
+    // and returns before dataValue.push(...) - discarding the WHOLE batch from the form while
+    // every file is already in storage.
+    //
+    // Note the test is for the terminal state, not for 'progress'. A file spends nearly all of
+    // its in-flight life at status 'info' (waitFileProcessing) covering the virus scan and the
+    // S3 PUT; 'progress' appears only at the very end, because our provider reports progress
+    // exactly once at 100% after the PUT returns (uploads.ts:33). Keying on 'progress' would
+    // leave the control live for almost the whole window.
+    //
+    // Formio's stock template offers an abort button here instead, but our provider never
+    // calls abortCallback (s3custom.js:26) and uploadFileOneChunk uses fetch with no
+    // AbortSignal, so it would do nothing.
+    if (status.status !== 'error') {
+      __p += '\n        <button type="button" ref="fileToSyncRemove" hidden></button>';
+    } else {
+      __p +=
+        '\n        <button type="button" class="' +
+        ((__t = ctx.iconClass('remove')) == null ? '' : __t) +
+        '" ref="fileToSyncRemove"><span class="sr-only">' +
+        ((__t = ctx.t('Dismiss message about ' + (status.originalName || status.name) + '.')) == null ? '' : __t) +
+        '</span></button>';
+    }
+    __p +=
+      '\n      </div>\n      <div class="fileSize col-sm-2 text-right">' +
       ((__t = ctx.fileSize(status.size)) == null ? '' : __t) +
       '</div>\n    </div>\n    <div class="row">\n      <div class="col-sm-12">\n        ';
     if (status.status === 'progress') {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleFile/Component.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleFile/Component.js
@@ -1,5 +1,6 @@
 /* tslint:disable */
 import { Components } from 'formiojs';
+import { FILE_UPLOAD_FILE_PATTERN } from '../../../additional-formio/constant';
 import { Constants } from '../Common/Constants.js';
 import editForm from './Component.form.js';
 const ParentComponent = Components.components.file;
@@ -21,7 +22,7 @@ export default class Component extends ParentComponent {
         webcamSize: 320,
         privateDownload: false,
         imageSize: '200',
-        filePattern: '*',
+        filePattern: FILE_UPLOAD_FILE_PATTERN,
         fileMinSize: '0KB',
         fileMaxSize: '100MB',
         uploadOnly: false,
@@ -30,6 +31,14 @@ export default class Component extends ParentComponent {
       ...extend,
     );
   }
+  // Form.io v5's File hardcodes `get defaultSchema() { return FileComponent.schema(); }` -
+  // the PARENT class, not `this.constructor`. Component#mergeSchema builds each instance from
+  // defaultSchema, so without this override our static schema() is never consulted and every
+  // instance silently falls back to the parent's defaults (notably filePattern: '*').
+  get defaultSchema() {
+    return this.constructor.schema();
+  }
+
   static editForm = editForm;
   static get builderInfo() {
     return {
@@ -64,6 +73,43 @@ export default class Component extends ParentComponent {
         }
       }
     } catch (e) {}
+  }
+  interpolateErrors(errors) {
+    const interpolated = super.interpolateErrors(errors);
+    // An empty required file field produces TWO errors saying the same thing: `required`, and
+    // `array_nonempty` from core's validateMultiple - which only fires because every file
+    // component is forced to multiple: true (formio-component-traversal.ts). The second renders
+    // as "<label> must be a non-empty array", which is developer-facing. Drop it when the plain
+    // required message is already being shown.
+    return interpolated.some((e) => e.ruleName === 'required')
+      ? interpolated.filter((e) => e.ruleName !== 'array_nonempty')
+      : interpolated;
+  }
+
+  handleFilesToUpload(files) {
+    // Client-side rejections render without a dismiss control (nothing was uploaded, so there
+    // is nothing to remove). Clear stale ones whenever the user tries again, otherwise they
+    // accumulate with no way to get rid of them.
+    this.filesToSync.filesToUpload = this.filesToSync.filesToUpload.filter((f) => !f.isValidationError);
+    return super.handleFilesToUpload(files);
+  }
+
+  prepareFileToDelete(fileInfo) {
+    // Form.io v5 locates the row to remove with `file.name === fileInfo.name`. Our file
+    // objects carry no `name` - the name lives in `filename` / `originalName` - so every
+    // comparison was `undefined === undefined`, findIndex always returned 0, and clicking
+    // any file's remove control deleted the FIRST file instead. Match on `id`, which is
+    // unique and present on every entry. (v4 used the clicked index and was correct.)
+    //
+    // A missing id yields -1, which Component.splice() ignores via hasOwnProperty, so the
+    // failure mode is "nothing removed" rather than "wrong file removed".
+    this.filesToSync.filesToDelete.push({
+      ...fileInfo,
+      status: 'info',
+      message: this.t(this.autoSync ? 'readyForRemovingFromStorage' : 'preparingFileToRemove'),
+    });
+    this.splice(this.dataValue.findIndex((file) => file.id === fileInfo.id));
+    this.redraw();
   }
   deleteFile(fileInfo) {
     const { options = {} } = this.component;

--- a/app/frontend/components/shared/chefs/index.tsx
+++ b/app/frontend/components/shared/chefs/index.tsx
@@ -1,18 +1,18 @@
 // The custom components in this directory are from the CHEFS codebase https://github.com/bcgov/common-hosted-form-service/tree/master/components
 // CJS interop: @formio/react does not re-export Formio — it lives in @formio/js
-import * as FormioReactModule from '@formio/react';
 import * as FormioJsModule from '@formio/js';
+import * as FormioReactModule from '@formio/react';
+import './styles.scss';
 const _fioReact = (FormioReactModule as any).default ?? FormioReactModule;
 const _fioJs = (FormioJsModule as any).default ?? FormioJsModule;
 const Form = _fioReact.Form as (typeof FormioReactModule)['Form'];
 const Templates = (_fioReact.Templates ?? _fioJs.Templates) as (typeof FormioReactModule)['Templates'];
 const Formio = _fioJs.Formio as (typeof import('@formio/js'))['Formio'];
-import './styles.scss';
 
 import { t } from 'i18next';
 import ChefsFormioComponents from './additional-formio';
-import { overridePanelTemplate } from './additional-formio/templates/panel';
 import { overrideFileTemplate } from './additional-formio/templates/file';
+import { overridePanelTemplate } from './additional-formio/templates/panel';
 import { overrideSelectTemplate } from './additional-formio/templates/select';
 
 import { FILE_UPLOAD_MAX_SIZE } from './additional-formio/constant';
@@ -24,6 +24,11 @@ const defaultButtonsTemplate = Templates.current.button.form;
 //panels - are for section blocks, to put things inside panels, we need to target the components section under the body
 
 Templates.current = {
+  // Formio v5's bootstrap5 template sets defaultIconset to 'bi' (Bootstrap Icons),
+  // which this project has never shipped — every icon rendered as an empty <i>.
+  // FontAwesome 4.7 is loaded in styles.scss, so pin the iconset back to 'fa'.
+  // Regression from the v4 -> v5 upgrade (f890065).
+  defaultIconset: 'fa',
   panel: {
     form: (ctx) => {
       let template = overridePanelTemplate(ctx);
@@ -100,4 +105,4 @@ const defaultOptions = {
   },
 };
 
-export { Form, Formio, defaultOptions };
+export { defaultOptions, Form, Formio };

--- a/app/frontend/components/shared/chefs/styles.scss
+++ b/app/frontend/components/shared/chefs/styles.scss
@@ -572,6 +572,47 @@
       }
     }
 
+    // The remove / dismiss controls are real <button>s so they are keyboard-operable and have
+    // an accessible name. Strip the browser chrome so they still read as bare icons.
+    [ref='removeLink'],
+    [ref='fileToSyncRemove'] {
+      background: none;
+      border: 0;
+      line-height: 1;
+      color: inherit;
+      cursor: pointer;
+      padding: 6px;
+      border-radius: var(--chakra-radii-full);
+
+      // Hover is the affordance that says the icon is interactive. Red only on hover, not at
+      // rest - a column of red x's next to several attached files reads as an error state
+      // rather than a set of controls.
+      &:hover {
+        color: $bcgov-font-error;
+        background-color: var(--chakra-colors-semantic-errorLight);
+      }
+
+      &:focus-visible {
+        outline: 2px solid var(--chakra-colors-focus);
+        outline-offset: 2px;
+      }
+    }
+
+    // a file rejected in the browser - never uploaded, so no remove control and no size
+    .file-rejected {
+      font-size: var(--chakra-fontSizes-sm);
+      padding: var(--chakra-space-2);
+      margin-bottom: 0.5rem;
+      border-radius: var(--chakra-radii-sm);
+    }
+
+    // allowed formats, shown under the drop zone
+    .file-pattern-hint {
+      font-size: var(--chakra-fontSizes-sm);
+      color: var(--chakra-colors-text-secondary);
+      margin-bottom: 0.5rem;
+    }
+
     .file {
       border-radius: var(--chakra-radii-sm);
       border: 1px solid var(--chakra-colors-border-light);
@@ -579,7 +620,7 @@
       font-size: var(--chakra-fontSizes-sm);
 
       .fileName {
-        [ref='fileStatusRemove'] {
+        [ref='fileToSyncRemove'] {
           color: $bcgov-font-error;
           margin: 0 var(--chakra-space-1);
           padding: 6px;


### PR DESCRIPTION
The control already existed but was invisible, deleted the wrong file, and could not be operated by keyboard. v5 defaults defaultIconset to 'bi', which this project has never shipped, so every icon rendered as an empty <i> - pinned to 'fa'. It matched files by file.name, which our file objects do not carry, so findIndex always returned 0 and it removed the first file rather than the clicked one - now matched on id. The remove and dismiss icons were <i tabindex="0"> with click-only handlers, so Tab reached them but Enter did nothing and screen readers announced nothing - both are now real buttons. Also restores upload feedback (the template read ctx.statuses, removed in v5, so failures had been silent since May) and rejects wrong file types in the browser rather than after a full upload.